### PR TITLE
Updated APQ LaTex design

### DIFF
--- a/.github/workflows/visual_diff.yml
+++ b/.github/workflows/visual_diff.yml
@@ -4,18 +4,22 @@ name: "Run visual diff"
 # events but only for the master branch
 on:
   workflow_run:
-    workflows: ["Build PDFs"]
-    types: [completed]
+    workflows: [ "Build PDFs" ]
+    types: [ completed ]
 
 jobs:
   tests:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: write
       checks: read
     continue-on-error: true
     steps:
+      - name: Running in response to ${{ github.event.workflow_run.event }} event
+        env:
+          EVENT_CONTEXT: ${{ toJson(github) }}
+        run: echo "$EVENT_CONTEXT"
+
       - name: Download repository
         uses: actions/checkout@v4
 
@@ -38,11 +42,6 @@ jobs:
         python-version: [ "3.12" ]
 
     steps:
-      - name: Running in response to ${{ github.event.workflow_run.event }} event
-        env:
-          EVENT_CONTEXT: ${{ toJson(github) }}
-        run: echo "$EVENT_CONTEXT"
-
       - name: Download repository
         uses: actions/checkout@v4
 

--- a/apqdesign/apqcolors.def
+++ b/apqdesign/apqcolors.def
@@ -1,14 +1,14 @@
 %% This is file `apqcolors.def' version 1.0 (2021/01/15),
 %% it is part of apqdesign, a modified version of
 %% TUDa-CI -- Corporate Design for TU Darmstadt
-%% version 3.07 (2020/10/21).
+%% version 3.38 (2024-05-07).
 %% The modifications for apqdesign were done 
 %% by Dominik Pfeiffer and Stephan Amann.
 %% Support for this modified version can not be guaranteed by the 
 %% maintainer of TUDa-CI!
 %% ----------------------------------------------------------------------------
 %%
-%%  Copyright (C) 2018--2020 by Marei Peischl <marei@peitex.de>
+%%  Copyright (C) 2018--2024 by Marei Peischl <marei@peitex.de>
 %%
 %% ============================================================================
 %% This work may be distributed and/or modified under the
@@ -23,7 +23,6 @@
 %%
 %% The Current Maintainers of this work are
 %%   Marei Peischl <tuda-ci@peitex.de>
-%%   Markus Lazanowski <latex@ce.tu-darmstadt.de>
 %%
 %% The development respository can be found at
 %% https://github.com/tudace/tuda_latex_templates
@@ -31,9 +30,9 @@
 %%
 %% ============================================================================
 %%
-\def\fileversion{3.07}
-\def\filedate{2020/10/21}
-\ProvidesFile{apqcolors.def}
+\def\fileversion{3.38}
+\def\filedate{2024-05-07}
+\ProvidesFile{tudacolors.def}
 [\filedate\space\fileversion\space Color definitions for tuda-ci]
 
 \definecolor{TUDa-0d}{cmyk/RGB/HTML}{0,0,0,.8/83,83,83/535353}

--- a/apqdesign/apqcolors.sty
+++ b/apqdesign/apqcolors.sty
@@ -1,14 +1,14 @@
 %% This is file `apqcolors.sty' version 1.0 (2021/01/15),
 %% it is part of apqdesign, a modified version of
 %% TUDa-CI -- Corporate Design for TU Darmstadt
-%% version 3.07 (2020/10/21).
+%% version 3.38 (2024-05-07).
 %% The modifications for apqdesign were done 
 %% by Dominik Pfeiffer and Stephan Amann.
 %% Support for this modified version can not be guaranteed by the 
 %% maintainer of TUDa-CI!
 %% ----------------------------------------------------------------------------
 %%
-%%  Copyright (C) 2018--2020 by Marei Peischl <marei@peitex.de>
+%%  Copyright (C) 2018--2024 by Marei Peischl <marei@peitex.de>
 %%
 %% ============================================================================
 %% This work may be distributed and/or modified under the
@@ -23,7 +23,6 @@
 %%
 %% The Current Maintainers of this work are
 %%   Marei Peischl <tuda-ci@peitex.de>
-%%   Markus Lazanowski <latex@ce.tu-darmstadt.de>
 %%
 %% The development respository can be found at
 %% https://github.com/tudace/tuda_latex_templates
@@ -31,13 +30,11 @@
 %%
 %% ============================================================================
 %%
-\def\fileversion{3.07}
-\def\filedate{2020/10/21}
+\def\fileversion{3.38}
+\def\filedate{2024-05-07}
 \NeedsTeXFormat{LaTeX2e}
-\RequirePackage{expl3}
-\ProvidesExplPackage{./apqdesign/apqcolors}{\filedate}{\fileversion}{Color definition for TU Darmstadt's tuda-ci bundle}
 
-\RequirePackage{l3keys2e}
+\ProvidesExplPackage{./apqdesign/apqcolors}{\filedate}{\fileversion}{Color definition for TU Darmstadt's tuda-ci bundle}
 
 \str_if_exist:NF \g_ptxcd_department_str {
 	\str_new:N \g_ptxcd_department_str
@@ -54,7 +51,7 @@
 	accentcolor .meta:n = {accent =#1},
 	textaccentcolor .meta:n = {textaccent = #1},
 	identbarcolor .meta:n = {identbar = #1},
-	color .meta:n = {accent=#1, textaccent=#1, identbar=#1},
+	color .code:n = \keys_set:nn {ptxcd/colors} {accent=#1, textaccent=#1, identbar=#1}\PassOptionsToPackage{color=}{siunitx},
 	text .choice:,
 	text/preferblack .code:n = \bool_gset_false:N \g_ptxcd_color_whitetext_bool,
 	text/preferwhite .code:n = \bool_gset_true:N  \g_ptxcd_color_whitetext_bool,
@@ -69,11 +66,11 @@
 	department / unknown .code:n = {
 		\str_gset:Nx \g_ptxcd_department_str {\l_keys_value_tl}
 	},
-	department .initial:V = \g_ptxcd_department_str,
+	departmentconfigprefix .tl_gset:N = \g__ptxcd_config_prefix_tl,
 	mecheng .meta:n = {department=mecheng},
 }
 
-\ProcessKeysOptions{ptxcd/colors}
+\ProcessKeyOptions[ptxcd/colors]
 
 \RequirePackage{xcolor}
 
@@ -91,12 +88,6 @@
 	\colorlet{TUDa-Arrow}{TUDa-Primary2}
 }
 
-\clist_map_inline:nn {accent, textaccent, identbar} {
-	\cs_if_exist:cF {\string\color@\tl_use:c {g_ptxcd_color_#1_tl}} {
-		\cs_if_exist:cT {\string\color@TUDa-\tl_use:c {g_ptxcd_color_#1_tl}} {
-			\tl_gset:cx {g_ptxcd_color_#1_tl} {TUDa-\tl_use:c {g_ptxcd_color_#1_tl}}
-	}}
-}
 
 \clist_const:Nn \c_ptxcd_color_forbid_textaccent_clist {TUDa-0a,TUDa-5a,TUDa-6a,TUDa-6b,TUDa-7a}
 \clist_const:Nn \c_ptxcd_color_allow_blacktext_clist {TUDa-0a,TUDa-0b,TUDa-0c,TUDa-1a,TUDa-2a,TUDa-3a,TUDa-4a,TUDa-4b,TUDa-4c,TUDa-5a,TUDa-5b,TUDa-5c,TUDa-6a,TUDa-6b,TUDa-6c,TUDa-7a,TUDa-7b,TUDa-7c,TUDa-8a,TUDa-8b,TUDa-8c,TUDa-9a,TUDa-9b,TUDa-10a}
@@ -107,33 +98,42 @@
 \msg_new:nnnn{apqcolors} {undefined-color} {The~ color~ #1~ you~ selected~ is~ not~ defined.} {See~ the~ tuda-ci~ manual~ for~ a~ list~ of~ available~ colors.}
 \msg_new:nnnn{apqcolors} {unselectable-color} {The~ color~ you~ selected~ (#1)~ must~ not~ be~ choosen~ for~ #2.} {See~ the~ Corporate~ Design~ Guidelines~ for~ further~ information.}
 
-%select accentcolor
-\exp_args:Nnx \colorlet{accentcolor}{\g_ptxcd_color_accent_tl}
-\bool_if:NTF \g_ptxcd_color_whitetext_bool {
-	\clist_if_in:NVTF \c_ptxcd_color_allow_whitetext_clist \g_ptxcd_color_accent_tl {
-		\colorlet{textonaccentcolor}{white}
-	} {
-		\colorlet{textonaccentcolor}{black}
-		\tl_if_in:NnT \g_ptxcd_color_accent_tl {TUDa} {\msg_warning:nnxx{apqcolors} {unselectable-color} {white} {textonaccentcolor}}
+\hook_new:n {ptxcd/init-colors}
+\hook_gput_code:nnn {ptxcd/init-colors} {tudacolors} {
+	\clist_map_inline:nn {accent, textaccent, identbar} {
+		\cs_if_exist:cF {\string\color@\tl_use:c {g_ptxcd_color_#1_tl}} {
+			\cs_if_exist:cT {\string\color@TUDa-\tl_use:c {g_ptxcd_color_#1_tl}} {
+				\tl_gset:cx {g_ptxcd_color_#1_tl} {TUDa-\tl_use:c {g_ptxcd_color_#1_tl}}
+		}}
 	}
-} {
-	\clist_if_in:NVTF \c_ptxcd_color_allow_blacktext_clist \g_ptxcd_color_accent_tl {
-		\colorlet{textonaccentcolor}{black}
+	\exp_args:Nnx \colorlet{accentcolor}{\g_ptxcd_color_accent_tl}
+	\bool_if:NTF \g_ptxcd_color_whitetext_bool {
+		\clist_if_in:NVTF \c_ptxcd_color_allow_whitetext_clist \g_ptxcd_color_accent_tl {
+			\colorlet{textonaccentcolor}{white}
+		} {
+			\colorlet{textonaccentcolor}{black}
+			\tl_if_in:NnT \g_ptxcd_color_accent_tl {TUDa} {\msg_warning:nnxx{tudacolors} {unselectable-color} {white} {textonaccentcolor}}
+		}
 	} {
-		\colorlet{textonaccentcolor}{white}
-		\tl_if_in:NnT \g_ptxcd_color_accent_tl {TUDa} {msg_warning:nnxx{apqcolors} {unselectable-color} {black} {textonaccentcolor}}
+		\clist_if_in:NVTF \c_ptxcd_color_allow_blacktext_clist \g_ptxcd_color_accent_tl {
+			\colorlet{textonaccentcolor}{black}
+		} {
+			\colorlet{textonaccentcolor}{white}
+			\tl_if_in:NnT \g_ptxcd_color_accent_tl {TUDa} {msg_warning:nnxx{tudacolors} {unselectable-color} {black} {textonaccentcolor}}
+		}
+	}
+	\colorlet{identbarcolor}{\g_ptxcd_color_identbar_tl}
+	\exp_args:NNx \clist_if_in:NnTF \c_ptxcd_color_forbid_textaccent_clist {\g_ptxcd_color_textaccent_tl} {
+		\msg_warning:nnxx{tudacolors} {unselectable-color} {\g_ptxcd_color_textaccent_tl} {textaccentcolor}
+		\colorlet{textaccentcolor}{black}
+	} {
+		\colorlet{textaccentcolor}{\g_ptxcd_color_textaccent_tl}
 	}
 }
 
-\colorlet{identbarcolor}{\g_ptxcd_color_identbar_tl}
+\file_if_exist_input:n {\g__ptxcd_config_prefix_tl\g_ptxcd_department_str-colors.def}
 
-
-\exp_args:NNx \clist_if_in:NnTF \c_ptxcd_color_forbid_textaccent_clist {\g_ptxcd_color_textaccent_tl} {
-	\msg_warning:nnxx{apqcolors} {unselectable-color} {\g_ptxcd_color_textaccent_tl} {textaccentcolor}
-	\colorlet{textaccentcolor}{black}
-} {
-	\colorlet{textaccentcolor}{\g_ptxcd_color_textaccent_tl}
-}
+\hook_use:n {ptxcd/init-colors}
 
 \colorlet{InfoBox}{white}
 

--- a/apqdesign/apqfonts.sty
+++ b/apqdesign/apqfonts.sty
@@ -1,14 +1,14 @@
-%% This is file `apqfonts.sty' version 1.0 (2021/01/15),
+%% This is file `apqfonts.sty' version 1.1 (2024-06-24),
 %% it is part of apqdesign, a modified version of
 %% TUDa-CI -- Corporate Design for TU Darmstadt
-%% version 3.07 (2020/10/21).
+%% version 3.38 (2024-05-07).
 %% The modifications for apqdesign were done 
 %% by Dominik Pfeiffer and Stephan Amann.
 %% Support for this modified version can not be guaranteed by the 
 %% maintainer of TUDa-CI!
 %% ----------------------------------------------------------------------------
 %%
-%%  Copyright (C) 2018--2020 by Marei Peischl <marei@peitex.de>
+%%  Copyright (C) 2018--2024 by Marei Peischl <marei@peitex.de>
 %%
 %% ============================================================================
 %% This work may be distributed and/or modified under the
@@ -23,7 +23,6 @@
 %%
 %% The Current Maintainers of this work are
 %%   Marei Peischl <tuda-ci@peitex.de>
-%%   Markus Lazanowski <latex@ce.tu-darmstadt.de>
 %%
 %% The development respository can be found at
 %% https://github.com/tudace/tuda_latex_templates
@@ -31,23 +30,23 @@
 %%
 %% ============================================================================
 %%
-\def\fileversion{3.07}
-\def\filedate{2020/10/21}
+\def\fileversion{3.38}
+\def\filedate{2024-05-07}
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{./apqdesign/apqfonts}
  [\filedate\space\fileversion\space
  font loading for TUDa-CI, TU Darmstadt's Corporate Design]
 
-\expandafter\newif\csname if@TUDa@T1\endcsname
+\expandafter\newif\csname if@ptxcd@T1\endcsname
 
-\DeclareOption{T1}{\csname @TUDa@T1true\endcsname}
+\DeclareOption{T1}{\csname @ptxcd@T1true\endcsname}
 \ProcessOptions\relax
 
 \RequirePackage{iftex}
 \RequirePackage{anyfontsize}
 
 \ifPDFTeX
-	\csname @TUDa@T1true\endcsname
+	\csname @ptxcd@T1true\endcsname
 	%Fallback for older versions
 	\expandafter\ifx\csname DeclareUnicodeCharacter\endcsname\relax
 	\RequirePackage[utf8]{inputenc}
@@ -58,7 +57,7 @@
 	\DeclareUnicodeCharacter{20AC}{\texteuro}
 \fi
 
-\csname if@TUDa@T1\endcsname
+\csname if@ptxcd@T1\endcsname
 	\ifLuaTeX
 		\RequirePackage[utf8]{luainputenc}
 	\fi
@@ -77,6 +76,23 @@
 \fi
 
 \RequirePackage{roboto}
+
+\csname if@ptxcd@T1\endcsname
+	\newcommand\robotoblackspaced{%
+		\robotoblack
+		\lsstyle
+	}
+\else
+	\newfontfamily\robotoblackspaced
+	   [ Numbers = {\roboto@figurealign,\roboto@figurestyle},
+		 UprightFont    = *-Black ,
+		 ItalicFont     = *-BlackItalic,
+		 LetterSpace=26,
+		 WordSpace=2.2
+	   ]
+	   {Roboto}
+\fi
+
 \IfFileExists{roboto-mono.sty}{
 	\RequirePackage{roboto-mono}
 }{
@@ -84,6 +100,8 @@
 	The font package roboto-mono.sty could not be found. Probably your TeX-distribution is outdated.\MessageBreak
 	For correct font setup either install it manually or update you distribution}
 }
+
+\def\ptxcd@sffamily@lining{\robototlf}
 
 \let\accentfont\robotoslab
 \DeclareTextFontCommand{\textaccent}{\accentfont}

--- a/apqdesign/apqpub.cls
+++ b/apqdesign/apqpub.cls
@@ -1,14 +1,9 @@
-%% This is file `apqpub.cls' version 1.0 (2021/01/15),
-%% it is part of apqdesign, a modified version of
+%% This is file `tudapub.cls' version 3.38 (2024-05-07),
+%% it is part of
 %% TUDa-CI -- Corporate Design for TU Darmstadt
-%% version 3.07 (2020/10/21).
-%% The modifications for apqdesign were done 
-%% by Dominik Pfeiffer and Stephan Amann.
-%% Support for this modified version can not be guaranteed by the 
-%% maintainer of TUDa-CI!
 %% ----------------------------------------------------------------------------
 %%
-%%  Copyright (C) 2018--2020 by Marei Peischl <marei@peitex.de>
+%%  Copyright (C) 2018--2024 by Marei Peischl <marei@peitex.de>
 %%
 %% ============================================================================
 %% This work may be distributed and/or modified under the
@@ -23,7 +18,6 @@
 %%
 %% The Current Maintainers of this work are
 %%   Marei Peischl <tuda-ci@peitex.de>
-%%   Markus Lazanowski <latex@ce.tu-darmstadt.de>
 %%
 %% The development respository can be found at
 %% https://github.com/tudace/tuda_latex_templates
@@ -31,14 +25,12 @@
 %%
 %% ============================================================================
 %%
-\def\fileversion{3.07}
-\def\filedate{2020/10/21}
+\def\fileversion{3.38}
+\def\filedate{2024-05-07}
 \NeedsTeXFormat{LaTeX2e}
-\RequirePackage{expl3}
+
 \ProvidesExplClass{./apqdesign/apqpub}
 	{\filedate}{\fileversion}{Publications using TU Darmstadt's Corporate Design (TUDa-CI)}
-
-\RequirePackage{l3keys2e}
 \RequirePackage{URspecialopts}
 
 \Define@specialopt@Module[ptxcd/pub]
@@ -55,15 +47,16 @@
 
 \int_new:N \g_ptxcd_ruledheaders_int
 \int_new:N \g_ptxcd_paper_int
-\msg_new:nnnn {apqpub} {compatibility-only} {
+\msg_new:nnn {apqpub} {compatibility-only} {
 	You~used~the~outdated~#1~option.\\
-	This~only~exists~due~to~compatibility~reasons.
-}{
-	Please~look~at~tuda-ci~documentation~for~further~information~and~avoid~using~outdated~options.
+	This~option~has~been~removed~with~tuda-ci~version~3.08.\\
+	See~documentation~for~the~updated~implementation.
 }
 
 \bool_new:N \g_ptxcd_geometry_bool
 \bool_new:N \g_ptxcd_custommargins_bool
+\bool_new:N \g_ptxcd_colorbacktitle_bool
+\bool_new:N \g_ptxcd_colorbacksubtitle_bool
 
 \keys_define:nn {ptxcd/pub} {
 	%twoside -> geometry + class
@@ -74,7 +67,7 @@
 	class/scrartcl .code:n  = \tl_gset:Nn \g_ptxcd_pub_class_tl {scrartcl},
 	class/book .meta:n = {class=scrbook},
 	class/scrbook .code:n  = \tl_gset:Nn \g_ptxcd_pub_class_tl {scrbook},
-	class .initial:n = scrartcl,%MAYBE add custom values
+	class .initial:n = scrartcl,
 	color .meta:n = {accentcolor=#1},
 	accentcolor .code:n = {\PassOptionsToPackage{accentcolor=#1}{apqcolors}},
 	textaccentcolor .code:n = {\PassOptionsToPackage{textaccentcolor=#1}{apqcolors}},
@@ -115,10 +108,23 @@
 	headline .initial:n =false,
 	colorback .bool_gset:N = \g_ptxcd_colorback_bool,
 	colorback .initial:n = true,
-	colortitleback .code:n =  \msg_warning:nnx {apqpub} {compatibility-only} {\l_keys_key_tl}
-		\keys_set:nn {ptxcd/pub} {logo=head,colorback=false},
+	colorback / title .code:n =
+		\bool_gset_true:N \g_ptxcd_colorbacktitle_bool
+		\bool_gset_true:N \g_ptxcd_colorback_bool
+		\bool_gset_false:N \g_ptxcd_colorbacksubtitle_bool,
+	colorback / body .code:n =
+		\bool_gset_false:N \g_ptxcd_colorbacktitle_bool
+		\bool_gset_false:N \g_ptxcd_colorbacksubtitle_bool
+		\bool_gset_true:N \g_ptxcd_colorback_bool,
+	colorback / head .code:n =
+		\bool_gset_true:N \g_ptxcd_colorbacktitle_bool
+		\bool_gset_true:N \g_ptxcd_colorback_bool
+		\bool_gset_true:N \g_ptxcd_colorbacksubtitle_bool,
+	colortitleback .code:n =  \msg_error:nnx {tudapub} {compatibility-only} {\l_keys_key_tl},
 	pdfa .bool_gset:N = \g_ptxcd_pdfa_bool,
 	pdfa .initial:n = true,
+	pdfx .bool_gset:N = \g_ptxcd_pdfx_bool,
+	pdfx .initial:n = true,
 	twocolumn .bool_gset:N = \g_ptxcd_twocolumn_bool,
 	twocolumn .default:n = true,
 	twocolumn .initial:n = false,
@@ -130,10 +136,16 @@
 	abstract .code:n = \prop_gput:Nnn \g_ptxcd_unknown_clsopts_prop {abstract} {#1},
 	abstract .initial:n =true,
 	logo .choice:,
-	logo / head .code:n = {\bool_gset_true:N \g_ptxcd_logo@inhead_bool},
-	logo / body .code:n = {\bool_gset_false:N \g_ptxcd_logo@inhead_bool},
-	logo / top .code:n = {\bool_gset_true:N \g_ptxcd_logo@inhead_bool},
-	logo / bottom .code:n = {\bool_gset_false:N \g_ptxcd_logo@inhead_bool},
+	logo / head .code:n = {
+		\bool_gset_true:N \g__ptxcd_LogoInHead_bool
+		\bool_gset_true:N \g_ptxcd_colorbacktitle_bool
+	},
+	logo / body .code:n = {
+		\bool_gset_false:N \g__ptxcd_LogoInHead_bool
+		\bool_gset_false:N \g_ptxcd_colorbacktitle_bool
+	},
+	logo / top .meta:n = {logo=head},
+	logo / bottom .code:n = {\bool_gset_false:N \g__ptxcd_LogoInHead_bool},
 	logo .initial:n = {body},
 	paper .choices:nn = {a0,a1,a2,a3,a4,a5,a6}{
 		\int_gset_eq:NN \g_ptxcd_paper_int  \l_keys_choice_int
@@ -164,6 +176,8 @@
 	department / unknown .code:n = {
 		\str_gset:Nx \g_ptxcd_department_str {\l_keys_value_tl}
 	},
+	departmentconfigprefix .tl_gset:N = \g__ptxcd_config_prefix_tl,
+	departmentconfigprefix .initial:n = tuda,
 	mecheng .meta:n = {department=mecheng},
 	departmentlogofile .tl_gset:N = \g_ptxcd_departmentlogo_tl,
 	departmentlogofile .initial:n =,
@@ -180,12 +194,39 @@
 
 \Module@Process@SpecialOptions[ptxcd/pub]
 
-\ProcessKeysOptions{ptxcd/pub}
+\ProcessKeyOptions[ptxcd/pub]
 
+\bool_if:NF \g_ptxcd_pdfa_bool {\bool_gset_false:N \g_ptxcd_pdfx_bool}
 
-%Option adjustments required for valid PDF/A
-\bool_if:NT  \g_ptxcd_pdfa_bool {
-  \PassOptionsToPackage{RGB}{xcolor}
+\bool_if:NT \g_ptxcd_pdfa_bool {
+	\msg_new:nnn {tudapub} {colors-to-rgb} {
+			You~did~not~add~a~color~profile.\\
+			I~will~use~the~default~one~and~automatically~try~to~convert~internal~colors~to~RGB.\\
+			This~is~required~to~be~able~to~create~PDF/A~compliance.
+	}
+
+	\cs_if_exist:NT \pdfmeta_standard_get:nN {
+		\pdfmeta_standard_get:nN  {outputintent_A} \l_tmpa_tl
+		\quark_if_no_value:NF \l_tmpa_tl  {
+			\bool_gset_false:N \g_ptxcd_pdfx_bool
+			\msg_new:nnn{tudapub} {prefer-lualatex} {
+				I~detected~usage~of~l3pdfmeta~(\DocumentMetadata)~to~create~PDF/A.\\
+				tudapub~will~not~load~pdfx~to~avoid~conflicts.\\
+				To~disable this message use pdfx=false.
+			}
+			\msg_info:nn {tudapub} {prefer-lualatex}
+		}
+
+		\prop_if_in:NnF \g__pdfmeta_outputintents_prop {GTS_PDFA1} {
+			\PassOptionsToPackage{RGB}{xcolor}
+			\msg_info:nn {tudapub} {colors-to-rgb}
+		}
+	}
+}
+
+\bool_if:NT \g_ptxcd_pdfx_bool {
+	\PassOptionsToPackage{RGB}{xcolor}
+	\msg_info:nn {tudapub} {colors-to-rgb}
 }
 
 \exp_args:Nx \tl_if_eq:nnT {\prop_item:Nn \g_ptxcd_clsopts_prop {fontsize}} {9pt}
@@ -359,6 +400,11 @@
 %Has to be loaded here due to headwidth options
 \usepackage[draft=false]{scrlayer-scrpage}
 
+\AddToHook{begindocument}[tudapub:BCOR-titlepage]{
+	\bool_if:NT  \g_ptxcd_BCOR_titlepage_bool
+		{\xdef\coverpageleftmargin{\the\dimexpr\coverpageleftmargin+\the\ta@bcor}}
+}
+
 \bool_if:NTF  \g_ptxcd_geometry_bool {
 	\RequirePackage{geometry}
 	\geometry{
@@ -379,7 +425,14 @@
 	\savegeometry{TUDa-marginpar}
 
 	\bool_if:NTF \g_ptxcd_custommargins_bool {
-		\AtBeginDocument{\savegeometry{TUDa-default}}
+		\AddToHook{begindocument}[tudapub:custommargins]{
+			\savegeometry{TUDa-default}
+			\bool_if:NTF  \g_ptxcd_marginpar_bool {
+				\dim_gset:Nn \g_ptxcd_headwidth_dim {\textwidth+\marginparwidth+\marginparsep}
+			}{
+				\dim_gset:Nn \g_ptxcd_headwidth_dim {\textwidth}
+			}
+		}
 		\tl_const:Nn \c_ptxcd_default_geometry_tl {TUDa-default}
 	}{
 		\bool_if:NTF  \g_ptxcd_marginpar_bool {
@@ -387,16 +440,21 @@
 		}  {
 			\tl_const:Nn \c_ptxcd_default_geometry_tl {TUDa-nomarginpar}
 		}
-		\AtBeginDocument{
+		\AddToHook{begindocument}[tudapub:custommargins-geometry]{
 			\loadgeometry{\c_ptxcd_default_geometry_tl}
-			\bool_if:NT \g_ptxcd_BCOR_titlepage_bool {\xdef\coverpageleftmargin{\the\dimexpr\coverpageleftmargin+\the\ta@bcor}}
 		}
 	}
 
-	\dim_gset:Nn \g_ptxcd_headwidth_dim 			  {\paperwidth-\g_ptxcd_innerMargin_dim-\g_ptxcd_outerMargin_dim-\Gm@bindingoffset}
+	\dim_gset:Nn \g_ptxcd_headwidth_dim {\paperwidth-\g_ptxcd_innerMargin_dim-\g_ptxcd_outerMargin_dim-\Gm@bindingoffset}
 
 	\cs_set:Nn \ptxcd_disable_marginpar: {\loadgeometry{TUDa-nomarginpar}}
 	\cs_set:Nn \ptxcd_restore_typearea: {\loadgeometry{\c_ptxcd_default_geometry_tl}}
+
+	\AddToHook{cmd/Gm@changelayout/after}[tudapub-restore-headwidth]{
+		\bool_if:NTF \g_ptxcd_marginpar_bool
+			{\KOMAoptions{headwidth=textwithmarginpar,footwidth=textwithmarginpar}}
+			{\KOMAoptions{headwidth=text,footwidth=text}}
+	}
 
 }{
 	\let\ptxcd_disable_marginpar:\relax
@@ -441,7 +499,7 @@
 \bool_if:NT \g_ptxcd_headline_bool {\KOMAoptions{headsepline=.5\c_ptxcd_smallrule_dim}}
 
 %Adjust headheight
-\AtBeginDocument{
+\AddToHook{begindocument}[apqpub:adjust-headheight]{
 \bool_if:NTF \g_ptxcd_marginpar_bool
 	{
 		\KOMAoptions {
@@ -553,6 +611,31 @@
 \tl_new:N  \g_ptxcd_titleimage_code_tl
 \tl_gset_eq:NN  \g_ptxcd_titleimage_code_tl \c_empty_tl
 \newcommand{\titleimage}[1]{\tl_gset:Nn \g_ptxcd_titleimage_code_tl {#1}}
+\box_new:N \l__ptxcd_titlegraphic_box
+
+\RequirePackage{trimclip}
+
+\NewDocumentCommand{\titlegraphic}{sm}{
+	\IfBooleanTF{#1}{
+		\tl_gset:Nn  \g_ptxcd_titleimage_code_tl  {
+			\hbox_set:Nn \l__ptxcd_titlegraphic_box {\raisebox{\depth}{#2}}
+			\box_resize_to_wd:Nn \l__ptxcd_titlegraphic_box {\width}
+			\dim_compare:nTF {\box_ht:N \l__ptxcd_titlegraphic_box -\height> \c_zero_dim}
+			{
+				\dim_set:Nn \l_tmpa_dim {.5\box_ht:N \l__ptxcd_titlegraphic_box - .5\height}
+				\clipbox{0pt~\dim_eval:n{\l_tmpa_dim}~0pt~\dim_eval:n{\l_tmpa_dim}}{\box_use:N \l__ptxcd_titlegraphic_box}
+			}{
+				\box_resize_to_ht:Nn \l__ptxcd_titlegraphic_box {\height}
+				\dim_set:Nn \l_tmpa_dim {(\box_wd:N \l__ptxcd_titlegraphic_box - \width) / 2}
+				\clipbox{\dim_eval:n{\l_tmpa_dim}~0pt~\dim_eval:n{\l_tmpa_dim}~0pt}{\box_use:N \l__ptxcd_titlegraphic_box}
+			}
+		}
+	}{
+		\tl_gset:Nn  \g_ptxcd_titleimage_code_tl {#2}
+	}
+}
+
+\let\titleimage\titlegraphic%for backwards compatbility
 
 \box_new:N  \g_ptxcd_title_box
 \skip_new:N \g_ptxcd_title_fill_skip
@@ -623,14 +706,14 @@
 		+\c_ptxcd_rulesep_dim
 	]{title.TUDa.image}
 
-	\bool_if:NT \g_ptxcd_logo@inhead_bool {
+	\bool_if:NT \g_ptxcd_colorbacktitle_bool {
 		\ModifyLayer[
-		addvoffset=\dim_eval:n {\box_ht:N \ptxcd_headrule_box+\box_dp:N \ptxcd_headrule_box-\g_ptxcd_titlerule_dim},
-		height={\box_ht:N \g_ptxcd_title_box+ \g_ptxcd_title_fill_skip+.5\c_ptxcd_logoheight_dim
-	}
-		]{title.TUDa.background}
-
-		\AddLayersToPageStyle{title.TUDa}{title.TUDa.background}
+			textarea,
+			addvoffset=\dim_eval:n {\box_ht:N \ptxcd_headrule_box+\box_dp:N \ptxcd_headrule_box-\g_ptxcd_titlerule_dim},
+			height={\box_ht:N \g_ptxcd_title_box+ \g_ptxcd_title_fill_skip+.5\c_ptxcd_logoheight_dim
+			\bool_if:NT \g_ptxcd_colorbacksubtitle_bool {+\box_dp:N \g_ptxcd_title_box}
+		}
+			]{title.TUDa.background}
 	}
 	\vspace*{\dim_eval:n {
 		-\topskip
@@ -642,13 +725,12 @@
 	\nointerlineskip
 	\ptxcd_setup_title_box:
 
-	\bool_if:NT \g_ptxcd_logo@inhead_bool {
+	\bool_if:NT \g__ptxcd_LogoInHead_bool {
 		\dim_compare:nT {\box_ht:N \g_ptxcd_title_info_box+ \box_dp:N \g_ptxcd_title_info_box  > \box_ht:N \g_ptxcd_title_box}
 			{\msg_warning:nn{apqpub} {infobox-too-high}}
 		\makebox[\linewidth][r]{\smash{
 				\raisebox{-\height}{
-					\makebox[2.2\c_ptxcd_logoheight_dim][l]{
-						%				}
+					\makebox[\__ptxcd_logowidth:][l]{
 						\box_use:N \g_ptxcd_title_info_box
 				}}
 		}}
@@ -660,7 +742,7 @@
 
 
 \newkomafont{institution}{\sffamily}
-\newkomafont{titleinfo}{\sffamily}
+\newkomafont{titleinfo}{\ptxcd@sffamily@lining}
 \setkomafont{subtitle}{\bfseries}
 \setkomafont{subject}{}
 \setkomafont{publishers}{}
@@ -679,9 +761,9 @@
 \cs_new:Nn \ptxcd_make_title_info_box:n {
 	\setlength{\fboxsep}{1.5mm}%
 	\colorbox{InfoBox}{
-	\makebox[\dim_eval:n {2.2\c_ptxcd_logoheight_dim-\fboxsep}][r]{
-		\parbox{2\c_ptxcd_logoheight_dim}{
-		\expandafter\fontsize\ptxcd_titlethanks_fontsize:\selectfont\usekomafont{institution}%
+	\makebox[\dim_eval:n {\__ptxcd_logowidth:-\fboxsep}][r]{
+		\parbox{\dim_eval:n {\__ptxcd_logowidth:+\fboxsep-\__ptxcd_logosep:}}{
+		\expandafter \fontsize\ptxcd_titlethanks_fontsize:\selectfont\usekomafont{institution}%
 		\raggedright%
 	#1
 	}}}
@@ -689,12 +771,12 @@
 
 \cs_new:Nn \ptxcd_make_title_logo_box:n {
 	\setlength{\fboxsep}{\z@}%
-	\parbox{2.2\c_ptxcd_logoheight_dim}{
+	\parbox{\__ptxcd_logowidth:}{
 		\colorbox{InfoBox}{
 			\rlap{
-			\makebox[2.5\c_ptxcd_logoheight_dim][r]{
-			\colorbox{InfoBox}{#1\hspace{.3\c_ptxcd_logoheight_dim}}
-			}
+				\makebox[\dim_eval:n {\__ptxcd_logowidth: + \__ptxcd_logosep:}][r]{
+					\colorbox{InfoBox}{#1\hspace{\__ptxcd_logosep:}}
+				}
 			}
 		}
 	}
@@ -727,7 +809,12 @@
 \DeclareNewLayer[textarea,background,mode=picture,
 	contents={
 		\tl_if_empty:NTF \g_ptxcd_titleimage_code_tl
-		{\bool_if:NT \g_ptxcd_colorback_bool {\putLL{\color{identbarcolor}\rule{\layerwidth}{\layerheight}}}}
+		{
+			\bool_if:NF \g_ptxcd_colorbacktitle_bool
+			{
+				\bool_if:NT \g_ptxcd_colorback_bool {\putLL{\color{identbarcolor}\rule{\layerwidth}{\layerheight}}}
+			}
+		}
 		{\putUL{\color{identbarcolor}
 				\let\width\layerwidth
 				\let\height\layerheight
@@ -735,8 +822,8 @@
 					\leavevmode\ignorespaces
 					\g_ptxcd_titleimage_code_tl
 					}}}}
-		\bool_if:NF \g_ptxcd_logo@inhead_bool {
-			\put(\dim_to_decimal_in_unit:nn {\layerwidth-2.2\c_ptxcd_logoheight_dim
+		\bool_if:NF \g__ptxcd_LogoInHead_bool {
+			\put(\dim_to_decimal_in_unit:nn {\layerwidth-\__ptxcd_logowidth:
 			} {\unitlength},
 			\dim_to_decimal_in_unit:nn {\layerheight-\box_ht:N \g_ptxcd_title_info_box - .5\c_ptxcd_logoheight_dim} {\unitlength}){
 				\rlap{\box_use:N \g_ptxcd_title_info_box}
@@ -745,8 +832,12 @@
 	}
 ]{title.TUDa.image}
 
-\DeclareNewLayer[textarea,background,mode=picture,
-contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
+\DeclareNewLayer[background,mode=picture,
+	contents={
+		\bool_lazy_and:nnT {\g_ptxcd_colorback_bool} {\g_ptxcd_colorbacktitle_bool} {
+			{\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
+		}
+	}
 ]{title.TUDa.background}
 
 \DeclareNewLayer[
@@ -762,7 +853,7 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 \cs_new:Nn \ptxcd_setup_title_box: {
 	\hbox_gset:Nn \g_ptxcd_title_info_box
 	{
-		\parbox{\dimexpr2.5\c_ptxcd_logoheight_dim}{
+		\parbox{\dim_eval:n {\__ptxcd_logowidth:+\__ptxcd_logosep:}}{
 		\seq_use:Nn \g_ptxcd_title_info_seq  {\par\nointerlineskip\vspace{\dim_eval:n {\c_ptxcd_largerule_dim+\c_ptxcd_rulesep_dim}}}
 		}
 	}
@@ -771,7 +862,7 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 \cs_new:Nn \ptxcd_setup_sponsor_box: {
 	\bool_if:nF {\seq_if_empty_p:N \g_ptxcd_sponsors_seq &&  \tl_if_empty_p:N \@sponsors} {
 		\hbox_gset:Nn \g_ptxcd_sponsor_box {
-			\def\height{\dimexpr.8\c_ptxcd_logoheight_dim\relax}
+			\edef\height{\noexpand\dimexpr\dim_eval:n {\__ptxcd_logosep: + .5\c_ptxcd_logoheight_dim}}
 			\parbox[t]{\textwidth}{
 				\rule{\linewidth}{\g_ptxcd_titlerule_dim}\par\nointerlineskip
 				\addvspace{\c_ptxcd_rulesep_dim}
@@ -789,42 +880,45 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 	}
 }
 
-\DeclareNewPageStyleByLayers{title.TUDa}{title.TUDa.rule,title.TUDa.image}
+\DeclareNewPageStyleByLayers{title.TUDa}{title.TUDa.background,title.TUDa.rule,title.TUDa.image}
 
 %Logos
 \RequirePackage{graphicx}
 
-\if_bool:N \g_ptxcd_pdfa_bool
+\if_bool:N \g_ptxcd_pdfx_bool
 
 	\msg_new:nnn{apqpub} {prefer-lualatex} {
 	You~use~pdfa-mode~in~#1.\\
 	This~can~lead~to~incompatiblities~especially~with~older~compiler~versions.\\
 	You~should~prefer~using~lualatex.
 	}
-
-
+	%only apply the hack if pdfx is older than the working version
 	\PassOptionsToPackage{a-2b}{pdfx}
 	\RequirePackage{pdfx}
+
+	\msg_new:nnnn{apqpub} {outdated-package-pdfa} {
+		Your~Version~of~the~#1-package~is~too~old~to~support~all~methods~required~by~apqpubs~pdfa-mode.\\
+		Either~update~your~TeX-distribution~or~switch~to~pdfa=false.
+	}{See~DEMO-tudapub~for~further~information.}
+
 
 	\sys_if_engine_pdftex:T {
 		\msg_warning:nnn{apqpub} {prefer-lualatex} {PDFTeX}
 	}
 
-	\sys_if_engine_pdftex:T {
+	\sys_if_engine_xetex:T {
 		\msg_warning:nnn{apqpub} {prefer-lualatex} {XeTeX}
 	}
 
-
+	\@ifpackagelater{xmpincl}{2021/09/22}{
+	}{
+		\msg_error:nn{apqpub}  {outdated-package-pdfa} {xmpincl}
+	}
 
 	\@ifpackagelater{pdfx}{2018/12/01}{
 	}{
-		\msg_new:nnnn{apqpub} {outdated-pdfx} {
-			Your~Version~of~the~PDFx-package~is~too~old~to~support~all~methods~required~by~apqpubs~pdfa-mode.\\
-			Either~update~your~TeX-distribution~or~switch~to~pdfa=false.
-		}{See~DEMO-apqpub~for~further~information.}
-		\msg_error:nn{apqpub} {outdated-pdfx}
+		\msg_error:nn{apqpub}  {outdated-package-pdfa} {pdfx}
 	}
-
 
 	%%hyperref
 	\hypersetup{hidelinks, unicode}
@@ -847,35 +941,26 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 		\cs_set:Npn \and {\exp_not:n {\exp_not:N \sep}}
 		\use:c {Hy@pdfstringtrue}
 		\tl_gset:Nf \g_ptxcd_xmp_title_tl {\@title}
-		\prop_gput_if_new:Nnx \g_ptxcd_MetaData_prop {title} {\tl_to_str:V \g_ptxcd_xmp_title_tl}
-		\prop_if_in:NnF \g_ptxcd_MetaData_prop {author} {
+		\prop_gput_if_new:Nnx \g_ptxcd_MetaData_prop {Title} {\tl_to_str:V \g_ptxcd_xmp_title_tl}
+		\prop_if_in:NnF \g_ptxcd_MetaData_prop {Author} {
 			\tl_gset:Nx \g_ptxcd_xmp_author_tl {\seq_use:Nn \g_ptxcd_author_seq {\exp_not:N \sep}}
 			\tl_gset:Nx \g_ptxcd_xmp_author_tl {\g_ptxcd_xmp_author_tl}
-			\prop_gput:Nnx \g_ptxcd_MetaData_prop {author} {\tl_to_str:V \g_ptxcd_xmp_author_tl}
+			\prop_gput:Nnx \g_ptxcd_MetaData_prop {Author} {\tl_to_str:V \g_ptxcd_xmp_author_tl}
 		}
-		\prop_gput_if_new:Nnn \g_ptxcd_MetaData_prop {publisher}{TU~Darmstadt}
-		\prop_gput_if_new:Nnn \g_ptxcd_MetaData_prop {creator}{LaTeX~using~TUDa-CI}
+		\prop_gput_if_new:Nnn \g_ptxcd_MetaData_prop {Publisher}{TU~Darmstadt}
+		\prop_gput_if_new:Nnn \g_ptxcd_MetaData_prop {Creator}{LaTeX~using~TUDa-CI}
 		\use:c {pdfx@localcommands}%should be held inside group
 		\prop_map_function:NN \g_ptxcd_MetaData_prop  \ptxcd_write_xmp_line:nn
 	\endgroup
 	\iow_close:N \ptxcd_xmpdata_stream
+		\let\ptxcd_pass_TitleData:\relax
 	}
 	\cs_new:Nn \ptxcd_write_xmp_line:nn {
 		\begingroup
 		\cs_set:Npn \sep {\exp_not:N \sep}
-		%Fallback test for older kernels
-		\cs_if_exist:NTF \str_uppercase:f {
-			\tl_set:Nx \l_tmpa_tl {
-				\str_uppercase:f {\tl_head:n {#1}}
-				\str_lowercase:f { \tl_tail:n {#1}}
-			}
-		} {
-			%may be removed in some time
-			\tl_set:Nx \l_tmpa_tl {\tl_mixed_case:n {#1}}
-		}
-		\cs_if_exist:cTF {\l_tmpa_tl}{
+		\cs_if_exist:cTF {#1}{
 			\iow_now:Nx \ptxcd_xmpdata_stream {
-				\c_backslash_str \l_tmpa_tl {\exp_not:n {#2}}
+				\c_backslash_str #1 {\exp_not:n {#2}}
 			}
 		}{
 			\msg_error:nnn{apqpub} {unknown-metadata} {#1}
@@ -883,7 +968,7 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 		\endgroup
 	}
 
-\prop_new:N \g_ptxcd_MetaData_prop
+	\prop_new:N \g_ptxcd_MetaData_prop
 
 	\newcommand*{\Metadata}[1]{
 		\keyval_parse:NNn  \use_none:n \ptxcd_set_metadata_prop:nn
@@ -891,28 +976,97 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 	}
 
 	\cs_set:Nn \ptxcd_set_metadata_prop:nn {
-	\exp_args:NNf \prop_gput:Nnn \g_ptxcd_MetaData_prop {\tl_lower_case:n{#1}}  {#2}
+		%Fallback test for older kernels doesn't support mixed case eintries
+		\cs_if_exist:NTF \text_titlecase_first:n {
+			\exp_args:NNf \prop_gput:Nnn \g_ptxcd_MetaData_prop {\text_titlecase_first:n {#1}}  {#2}
+		} {
+			\exp_args:NNx \prop_gput:Nnn \g_ptxcd_MetaData_prop {
+					\str_uppercase:f {\tl_head:n {#1}}
+					\str_lowercase:f {\tl_tail:n {#1}}
+				} {#2}
+		}
 	}
 
 	\msg_new:nnnn{apqpub} {unknown-metadata} {
-	You~ used~ the~ #1~ metadata~ entry.\\
-	I~ don't~ know~ how~ to~ handle~ that.\\
-	It~ will~ be~ ignored.
+		You~ used~ the~ #1~ metadata~ entry.\\
+		I~ don't~ know~ how~ to~ handle~ that.\\
+		It~ will~ be~ ignored.
 	} {See~ TUDa-CI~ or~ pdfx~ documentation~ for~ details.}
 \else:
-	\msg_new:nnn{apqpub} {no-pdfa}{The~ apqpub~ class~ won't~ create~ PDF/A-mode.}
-	\msg_info:nn{apqpub} {no-pdfa}
-	%%hyperref
-	\RequirePackage[hidelinks, unicode]{hyperref}
+	\PassOptionsToPackage{hidelinks, unicode}{hyperref}
+	\RequirePackage{hyperref}
+	\hypersetup{pdfcreator=LaTeX~using~TUDa-CI}
 
-	\newcommand{\Metadata}[1]{\ClassError{apqpub}{You~cannot~use~\string\Metadata\ ~with~pdfa=false.}{}}
+	\msg_new:nnnn {apqpub} {metadata-to-hypersetup} {
+		You~don't~use~pdfx.~
+		Here~the~\string\Metadata\~command~only~exists~for~compatibility~reasons.\\
+		I~will~pass~the~data~to~ḩypersetup.
+	}{
+		If~possible~please~use~hyperref's~\strung\hypersetup~command~for~the~metadata~directly.\\
+		See~hyperref~documentation~for~details~on~usage.
+	}
+
+	\newcommand*{\Metadata}[1]{
+		\tl_set:Nn \l_tmpa_tl {#1}
+		\tl_replace_all:Nnn \l_tmpa_tl {\sep} {;~}% pdfx-Syntax compatibility
+		\clist_map_inline:Nn \l_tmpa_tl {
+			\exp_args:Nx \hypersetup{pdf\tl_trim_spaces:n {##1}}
+		}
+		\msg_warning:nn {apqpub} {metadata-to-hypersetup}
+	}
+
+
+	\cs_new:Nn \ptxcd_pass_TitleData: {
+		% check if pdfmanagement is active
+		\prop_if_exist:NTF \g__pdfmanagement_documentproperties_prop {
+			\prop_set_eq:NN \l_tmpa_prop \g__pdfmanagement_documentproperties_prop
+		} {
+			\prop_set_eq:NN \l_tmpa_prop   \g__hyp_documentproperties_prop
+		}
+
+		% title
+		\prop_if_in:NnF \l_tmpa_prop {hyperref/pdftitle} {
+			\begingroup
+			\def\newline{}
+			\def\\{}
+			\let\thanks\use_none:n
+			\tl_gset:Nf \g_tmpa_tl {\@title}
+			\endgroup
+			\hypersetup{pdftitle={\tl_to_str:V \g_tmpa_tl}}
+		}
+
+		% author
+		\prop_if_in:NnF \l_tmpa_prop {hyperref/pdfauthor} {
+			\begingroup
+				\def\newline{}
+				\def\\{}
+				\let\thanks\use_none:n
+				\tl_gset:Nx \g_tmpa_tl {\seq_use:Nn \g_ptxcd_author_seq {\exp_not:N \and}}
+				\tl_gset:Nx \g_tmpa_tl  {\g_tmpa_tl }
+			\endgroup
+			\hypersetup{pdfauthor=\g_tmpa_tl}
+		}
+	}
+
+	\bool_if:NF \g_ptxcd_pdfa_bool {
+		\msg_new:nnn{tudapub} {no-pdfa}{The~ tudapub~ class~ won't~ create~ PDF/A-mode.}
+		\msg_info:nn{tudapub} {no-pdfa}
+	}
 \fi:
+
+\RequirePackage{bookmark}
 
 \box_new:N  \g_ptxcd_sponsor_box
 \seq_new:N \g_ptxcd_sponsors_seq
 \def\AddSponsor{\seq_gput_right:Nn \g_ptxcd_sponsors_seq}
 \def\sponsors#1{\def\@sponsors{#1}}
 \sponsors{}
+
+\cs_new:Npn \ptxcd_title_footnote:w [#1] #2 {
+	\textsuperscript{ \ptxcd_title_footnotestyle:n {#1}}#2
+}
+
+\cs_set_eq:NN \ptxcd_title_footnotestyle:n \@fnsymbol
 
 \str_if_eq:VnTF \g_ptxcd_pubType_tl  {thesis} {
 	\input{apqthesis.cfg}
@@ -925,9 +1079,6 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 		\msg_error:nnn {apqpub} {only-thesis} {#1}
 	}
 }
-\newcommand*{\ptxcd_title@footnote}[2][1]{
-\textsuperscript{\@fnsymbol{#1}}#2
-}
 
 % The following macro is an adapted version of the corresponding KOMA-Script macro
 % Copyright (c) 1994-2019 Markus Kohm [komascript at gmx info]
@@ -935,21 +1086,21 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 	\def\and{,~ }
 	\cs_if_exist_use:N \ptxcd_pass_TitleData:
 	\if@titlepage
+	\edef\titlepage@restore{%
+		\noexpand\endgroup
+		\noexpand\global\noexpand\@colht\the\@colht
+		\noexpand\global\noexpand\@colroom\the\@colroom
+		\noexpand\global\vsize\the\vsize
+		\noexpand\global\noexpand\@titlepageiscoverpagefalse
+		\noexpand\let\noexpand\titlepage@restore\noexpand\relax
+	}%
 	\ptxcd_disable_marginpar:
 	\begin{titlepage}
 		\setcounter{page}{%
 			#1%
 		}%
-		\def\thefootnote{\fnsymbol{footnote}}
+		\def\thefootnote{\ptxcd_title_footnotestyle:n {\c@footnote}}
 		\if@titlepageiscoverpage
-		\edef\titlepage@restore{%
-			\noexpand\endgroup
-			\noexpand\global\noexpand\@colht\the\@colht
-			\noexpand\global\noexpand\@colroom\the\@colroom
-			\noexpand\global\vsize\the\vsize
-			\noexpand\global\noexpand\@titlepageiscoverpagefalse
-			\noexpand\let\noexpand\titlepage@restore\noexpand\relax
-		}%
 		\begingroup
 		\topmargin=\dimexpr \coverpagetopmargin-1in\relax
 		\oddsidemargin=\dimexpr \coverpageleftmargin-1in\relax
@@ -974,8 +1125,8 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 		\ptxcd_setup_sponsor_box:
 		\hbox_gset:Nn \g_ptxcd_title_box {
 			\parbox[t]{\linewidth}{
-				\begin{minipage}[b]{\bool_if:NT \g_ptxcd_logo@inhead_bool {.75}\linewidth}
-					\bool_if:NT \g_ptxcd_logo@inhead_bool {\color{textonaccentcolor}}
+				\begin{minipage}[b]{\bool_if:NT \g__ptxcd_LogoInHead_bool {.75}\linewidth}
+					\bool_lazy_and:nnT {\g_ptxcd_colorback_bool} {\g_ptxcd_colorbacktitle_bool} {\color{textonaccentcolor}}
 					\tl_if_empty:NF \@titlehead {
 						\begin{addmargin}{3mm}
 							{\usekomafont{titlehead}{\@titlehead\par}}
@@ -994,6 +1145,7 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 						{\rule{0pt}{.5\c_ptxcd_logoheight_dim}}
 					\end{addmargin}
 				\end{minipage}%
+				\bool_if:NT \g_ptxcd_colorbacksubtitle_bool {\color{textonaccentcolor}}
 				\par\nointerlineskip
 				\rule{\linewidth}{\g_ptxcd_titlerule_dim}\par\vspace{\c_ptxcd_rulesep_dim}
 				\begin{addmargin}{3mm}
@@ -1015,21 +1167,22 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 					\expandafter\fontsize\ptxcd_titlethanks_fontsize:\selectfont\par
 					\rule{\linewidth}{\g_ptxcd_titlerule_dim}\par
 					\begin{addmargin}{3mm}
-						\let\footnotetext\ptxcd_title@footnote
+						\let\footnotetext\ptxcd_title_footnote:w
 						\@thanks
 					\end{addmargin}
 					\par\vspace{-\dp\strutbox}
-					\let\@thanks\@empty
 				}
+				\normalcolor
 				\rule{\linewidth}{\g_ptxcd_titlerule_dim}\par}
 		}
+		\let\@thanks\@empty
 		\ptxcd_adjust_titlepage_style:
 		\thispagestyle{title.TUDa}
 		\nointerlineskip\box_use:N \g_ptxcd_title_box
 		\par
 		\vfill
 		\box_if_empty:NTF \g_ptxcd_sponsor_box {
-				\raisebox{-\c_ptxcd_rulesep_dim}[0pt][0pt]{\rule{\linewidth}{\g_ptxcd_titlerule_dim}}
+			\raisebox{-\c_ptxcd_rulesep_dim}[0pt][0pt]{\rule{\linewidth}{\g_ptxcd_titlerule_dim}}
 		}{
 			\box_use:N \g_ptxcd_sponsor_box
 		}
@@ -1114,7 +1267,7 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 	\@maketitle
 	\fi
 	\ifx\titlepagestyle\@empty\else\thispagestyle{\titlepagestyle}\fi
-	\@thanks\global\let\@thanks\@empty
+	\global\let\@thanks\@empty
 	\endgroup
 	\fi
 }
@@ -1125,7 +1278,12 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 \newcommand*{\SetPaperID}[2]{
 	\hbox_gset:Nn \g_ptxcd_PaperID_box {
 		\usekomafont{paperid}
+		\if@titlepage
 		\dim_set:Nn \l_tmpa_dim {\exp_last_unbraced:No \use_i:nn \ptxcd_title_fontsize: + \exp_last_unbraced:No \use_ii:nn \ptxcd_title_fontsize:}
+		\else
+		\Huge
+		\dim_set:Nn \l_tmpa_dim {1.8\baselineskip}
+		\fi
 		\fontsize{1.1\l_tmpa_dim}{1.1\l_tmpa_dim}
 		\selectfont
 		#1{\Huge #2}
@@ -1148,35 +1306,44 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 	\usekomafont{disposition}
 	\hsize=\g_ptxcd_headwidth_dim
 	\setlength{\fboxsep}{\z@}
-	\bool_if:NT \g_ptxcd_colorback_bool {\colorbox{accentcolor}}{\parbox[t]{\g_ptxcd_headwidth_dim}{
+	\def\thefootnote{\ptxcd_title_footnotestyle:n {\c@footnote}}
+	\bool_if:NT \g_ptxcd_colorback_bool {\bool_set_true:N \g_ptxcd_colorbacktitle_bool}
+	\bool_if:NT \g_ptxcd_colorbacktitle_bool {\colorbox{identbarcolor}}
+	{\parbox[t]{\g_ptxcd_headwidth_dim}{
 			\rule{\z@}{.5\c_ptxcd_logoheight_dim}\par\nointerlineskip
 			\raisebox{-\height}{%
-				\begin{minipage}[t]{\dimexpr\linewidth-2.2\c_ptxcd_logoheight_dim-1ex}
-					\bool_if:NT \g_ptxcd_colorback_bool  {\begin{addmargin}{.5\c_ptxcd_largerule_dim}}
+				\begin{minipage}[t]{\dim_eval:n {\linewidth-\__ptxcd_logowidth:-1ex}}
+					\bool_if:NT \g_ptxcd_colorbacktitle_bool  {\begin{addmargin}{.5\c_ptxcd_largerule_dim}}
 						\raggedright
 						\bool_if:NT \g_ptxcd_colorback_bool {\color{textonaccentcolor}}
 						\tl_if_empty:NF \@titlehead {\usekomafont{titlehead}{\@titlehead\par}}
-						\leavevmode
-						{\Huge\usekomafont{title}{
-						\Huge
-						\@title \par
-						}}%
-						\vskip 1em
-						\bool_if:NTF \g_ptxcd_colorback_bool {\end{addmargin}} {\par}
+						\box_if_empty:NF \g_ptxcd_PaperID_box  {\begin{addmargin}[\dim_eval:n {\box_wd:N\g_ptxcd_PaperID_box+.5\c_ptxcd_logoheight_dim}]{0pt}}
+							\raggedright
+							\bool_if:NT \g_ptxcd_colorback_bool {\color{textonaccentcolor}}
+							\tl_if_empty:NF \@titlehead {\usekomafont{titlehead}{\@titlehead\par}}
+							\leavevmode\usekomafont{title}%
+							\Huge
+							\llap{\raisebox{\dimexpr-\height+.5\baselineskip}[0pt][0pt]{\box_use:N \g_ptxcd_PaperID_box}\hspace{.5\c_ptxcd_logoheight_dim}}
+							\@title\strut
+							\par
+							\box_if_empty:NTF \g_ptxcd_PaperID_box
+							{\vskip1em}
+							{\rule{0pt}{.5\c_ptxcd_logoheight_dim}}
+						\box_if_empty:NF \g_ptxcd_PaperID_box {\end{addmargin}}
+					\bool_if:NTF \g_ptxcd_colorbacktitle_bool {\end{addmargin}} {\par}
 			\vspace{\dim_eval:n {\c_ptxcd_largerule_dim+\c_ptxcd_rulesep_dim}}
 			\end{minipage}
 		}
 		\hfill
 		\raisebox{-\height}{
 		\ptxcd_setup_title_box:
-		\makebox[2.2\c_ptxcd_logoheight_dim][l]{
+		\makebox[\__ptxcd_logowidth:][l]{
 		\box_use:N \g_ptxcd_title_info_box
 		}
 		}
-		\dim_compare:nNnTF {\box_ht:N \g_ptxcd_title_info_box + \box_ht:N \g_ptxcd_title_info_box} > {1.1\c_ptxcd_logoheight_dim}
+		\dim_compare:nNnTF {\box_ht:N \g_ptxcd_title_info_box + \box_ht:N \g_ptxcd_title_info_box} > {(\__ptxcd_logowidth:)/2}
 				{\vspace{\c_ptxcd_largerule_dim}}
 				{\vspace{.5\c_ptxcd_logoheight_dim}}
-
 		\par
 	}}
 	\par
@@ -1193,7 +1360,7 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 	\rule{\g_ptxcd_headwidth_dim}{\g_ptxcd_titlerule_dim}
 	\expandafter\fontsize\ptxcd_titlethanks_fontsize:\selectfont
 	\begin{addmargin}{.5\c_ptxcd_largerule_dim}
-		\let\footnotetext\ptxcd_title@footnote
+		\let\footnotetext\ptxcd_title_footnote:w
 		\@thanks
 		\vspace{\c_ptxcd_rulesep_dim}
 	\end{addmargin}
@@ -1236,13 +1403,13 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 
 
 %Anpassungen marginpar
-\cs_set_eq:NN\ptxcd_orig@marginpar:\marginpar
+\cs_set_eq:NN\ptxcd_orig@marginpar:w \marginpar
 \newkomafont{marginpar}{\accentfont\color{textaccentcolor}}
 \RenewDocumentCommand{\marginpar}{om}{
 	\IfNoValueTF{#1}{
-		\ptxcd_orig@marginpar:{\leavevmode\usekomafont{marginpar}#2}
+		\ptxcd_orig@marginpar:w {\leavevmode\usekomafont{marginpar}#2}
 	}{
-		\ptxcd_orig@marginpar:[\leavevmode\usekomafont{marginpar}#1]{\leavevmode\usekomafont{marginpar}#2}
+		\ptxcd_orig@marginpar:w [{\leavevmode\usekomafont{marginpar}#1}]{\leavevmode\usekomafont{marginpar}#2}
 	}
 }
 
@@ -1309,6 +1476,6 @@ contents={\color{identbarcolor}\rule{\layerwidth}{\layerheight}}
 	\let\Iftocfeature\iftocfeature
 }
 
-\file_if_exist_input:n {tuda\g_ptxcd_department_str.cfg}
+\file_if_exist_input:n {\g__ptxcd_config_prefix_tl\g_ptxcd_department_str.cfg}
 \endinput
 %End of class apqpub.cls

--- a/apqdesign/apqrules.sty
+++ b/apqdesign/apqrules.sty
@@ -1,4 +1,4 @@
-%% This is file `apqrules.sty' version 1.0 (2021/01/15),
+%% This is file `apqrules.sty' version 3.38 (2024-05-07),
 %% it is part of apqdesign, a modified version of
 %% TUDa-CI -- Corporate Design for TU Darmstadt
 %% version 3.07 (2020/10/21).
@@ -8,7 +8,7 @@
 %% maintainer of TUDa-CI!
 %% ----------------------------------------------------------------------------
 %%
-%%  Copyright (C) 2018--2020 by Marei Peischl <marei@peitex.de>
+%%  Copyright (C) 2018--2024 by Marei Peischl <marei@peitex.de>
 %%
 %% ============================================================================
 %% This work may be distributed and/or modified under the
@@ -23,7 +23,6 @@
 %%
 %% The Current Maintainers of this work are
 %%   Marei Peischl <tuda-ci@peitex.de>
-%%   Markus Lazanowski <latex@ce.tu-darmstadt.de>
 %%
 %% The development respository can be found at
 %% https://github.com/tudace/tuda_latex_templates
@@ -31,14 +30,10 @@
 %%
 %% ============================================================================
 %%
-\def\fileversion{3.07}
-\def\filedate{2020/10/21}
+\def\fileversion{3.38}
+\def\filedate{2024-05-07}
 \NeedsTeXFormat{LaTeX2e}
-\RequirePackage{expl3}
 \ProvidesExplPackage{./apqdesign/apqrules}{\filedate}{\fileversion}{Creation of colored bars for tuda-ci bundle}
-
-
-\RequirePackage{l3keys2e}
 
 \str_if_exist:NF \g_ptxcd_department_str {
 	\str_new:N \g_ptxcd_department_str
@@ -58,8 +53,8 @@
 		\tl_set:Nn \l_ptxcd_tmpa_tl {c_ptxcd_
 			\clist_item:nn {largerule, rulesep, smallrule, logoheight} {##1}
 			_dim}
-		\dim_if_exist:cF {\l_ptxcd_tmpa_tl} {\dim_new:c {\l_ptxcd_tmpa_tl}}
-		\dim_gset:cn {\l_ptxcd_tmpa_tl} {\seq_item:Nn \l_ptxcd_tmpa_seq {##1}}
+		\dim_if_exist:cT {\l_ptxcd_tmpa_tl} {\cs_undefine:c {\l_ptxcd_tmpa_tl}}
+		\dim_const:cn {\l_ptxcd_tmpa_tl} {\seq_item:Nn \l_ptxcd_tmpa_seq {##1}}
 	}
 	\dim_gset:Nn \g_ptxcd_titlerule_dim {.5\c_ptxcd_smallrule_dim}
 }
@@ -89,11 +84,10 @@
 	department / unknown .code:n = {
 		\str_gset:Nx \g_ptxcd_department_str {\l_keys_value_tl}
 	},
-	department .initial:V = \g_ptxcd_department_str,
 	mecheng .meta:n = {department=mecheng},
 }
 
-\ProcessKeysOptions{ptxcd/rules}
+\ProcessKeyOptions[ptxcd/rules]
 
 \RequirePackage{apqcolors}
 \RequirePackage{xparse}
@@ -111,9 +105,13 @@
 }
 
 
-\str_case:Vn \g_ptxcd_department_str {
+\cs_if_exist_use:NF \str_case:Vn \str_case:on
+	\g_ptxcd_department_str {
 	{mecheng} {\bool_gset_true:N \g_ptxcd_simple_rules_bool}
 }
+
+\cs_new:Nn \__ptxcd_logowidth: {\dim_eval:n {2.2\c_ptxcd_logoheight_dim}}
+\cs_new:Nn \__ptxcd_logosep:{\dim_eval:n {0.3\c_ptxcd_logoheight_dim}}
 
 \NewDocumentCommand{\ptxcd_makeheadrule}{som}{
 	\keys_set:nn {ptxcd/rules} {

--- a/apqdesign/apqthesis.cfg
+++ b/apqdesign/apqthesis.cfg
@@ -8,7 +8,7 @@
 %% maintainer of TUDa-CI!
 %% ----------------------------------------------------------------------------
 %%
-%%  Copyright (C) 2018--2020 by Marei Peischl <marei@peitex.de>
+%%  Copyright (C) 2018--2024 by Marei Peischl <marei@peitex.de>
 %%
 %% ============================================================================
 %% This work may be distributed and/or modified under the
@@ -23,7 +23,6 @@
 %%
 %% The Current Maintainers of this work are
 %%   Marei Peischl <tuda-ci@peitex.de>
-%%   Markus Lazanowski <latex@ce.tu-darmstadt.de>
 %%
 %% The development respository can be found at
 %% https://github.com/tudace/tuda_latex_templates
@@ -31,8 +30,8 @@
 %%
 %% ============================================================================
 %%
-\def\fileversion{3.07}
-\def\filedate{2020/10/21}
+\def\fileversion{3.38}
+\def\filedate{2024-05-07}
 \RequirePackage{expl3}
 \ProvidesExplFile{apqthesis.cfg}
 {\filedate}{\fileversion}{Special Features for publication type 'thesis' using TU Darmstadt's Corporate Design (tuda-ci)}
@@ -46,29 +45,29 @@
 %Declare macros for department
 \cs_new:Nn \ptxcd_select_department:n {
 	\str_case:nnTF {#1} {
-		{arch}   {\ptxcd_declare_caption:Nnn \ptxcd_department {Architektur} {Architecture}}
-		{bauing} {\ptxcd_declare_caption:Nnn \ptxcd_department {Bau-~und~Umweltingenieurwissenschaften}{Civil~and~Environmental~Engineering}}
-		{bio}    {\ptxcd_declare_caption:Nnn \ptxcd_department {Biologie}{Biology}}
-		{chem}   {\ptxcd_declare_caption:Nnn \ptxcd_department {Chemie}{Chemistry}}
-		{etit}   {\ptxcd_declare_caption:Nnn \ptxcd_department {Elektrotechnik~und~Informationstechnik}{Electrical~Engineering~and~Information~Technology}}
-		{gugw}   {\ptxcd_declare_caption:Nnn \ptxcd_department {Gesellschafts-~und~Geschichtswissenschaften}{History~and~Social~Sciences}}
-		{humanw} {\ptxcd_declare_caption:Nnn \ptxcd_department {Humanwissenschaften}{Human~Sciences}}
-		{inf}    {\ptxcd_declare_caption:Nnn \ptxcd_department {Informatik}{Computer~Science}}
-		{mb}     {\ptxcd_declare_caption:Nnn \ptxcd_department {Maschinenbau}{Mechanical~Engineering}}
-		{matgeo} {\ptxcd_declare_caption:Nnn \ptxcd_department {Material-~und~Geowissenschaften}{Materials~and~Earth~Sciences}}
-		{math}   {\ptxcd_declare_caption:Nnn \ptxcd_department {Mathematik}{Mathematics}}
-		{phys}   {\ptxcd_declare_caption:Nnn \ptxcd_department {Physik}{Physics}}
-		{wi}     {\ptxcd_declare_caption:Nnn \ptxcd_department {Rechts-~und~Wirtschaftswissenschaften}{Law~and~Economics}}
+		{arch}   {\ptxcd_declare_caption:Nnn \ptxcd_department: {Architektur} {Architecture}}
+		{bauing} {\ptxcd_declare_caption:Nnn \ptxcd_department: {Bau-~und~Umweltingenieurwissenschaften}{Civil~and~Environmental~Engineering}}
+		{bio}    {\ptxcd_declare_caption:Nnn \ptxcd_department: {Biologie}{Biology}}
+		{chem}   {\ptxcd_declare_caption:Nnn \ptxcd_department: {Chemie}{Chemistry}}
+		{etit}   {\ptxcd_declare_caption:Nnn \ptxcd_department: {Elektrotechnik~und~Informationstechnik}{Electrical~Engineering~and~Information~Technology}}
+		{gugw}   {\ptxcd_declare_caption:Nnn \ptxcd_department: {Gesellschafts-~und~Geschichtswissenschaften}{History~and~Social~Sciences}}
+		{humanw} {\ptxcd_declare_caption:Nnn \ptxcd_department: {Humanwissenschaften}{Human~Sciences}}
+		{inf}    {\ptxcd_declare_caption:Nnn \ptxcd_department: {Informatik}{Computer~Science}}
+		{mb}     {\ptxcd_declare_caption:Nnn \ptxcd_department: {Maschinenbau}{Mechanical~Engineering}}
+		{matgeo} {\ptxcd_declare_caption:Nnn \ptxcd_department: {Material-~und~Geowissenschaften}{Materials~and~Earth~Sciences}}
+		{math}   {\ptxcd_declare_caption:Nnn \ptxcd_department: {Mathematik}{Mathematics}}
+		{phys}   {\ptxcd_declare_caption:Nnn \ptxcd_department: {Physik}{Physics}}
+		{wi}     {\ptxcd_declare_caption:Nnn \ptxcd_department: {Rechts-~und~Wirtschaftswissenschaften}{Law~and~Economics}}
 	}
 	{
 		\ptxcd_declare_caption:Nnn \departmentname {Fachbereich} {department}
-		\ptxcd_declare_caption:Nnn \ptxcd_departmentprefix {im~ \departmentname}{in~the~\departmentname{}~ of}
-		\ptxcd_declare_caption:Nnn \departmentfullname {\departmentname{}~ \ptxcd_department} { \ptxcd_department{}~ \text_titlecase:n{\departmentname}}
+		\ptxcd_declare_caption:Nnn \ptxcd_departmentprefix: {im~ \departmentname}{in~the~\departmentname{}~ of}
+		\ptxcd_declare_caption:Nnn \departmentfullname {\departmentname{}~ \ptxcd_department:} { \ptxcd_department:{}~ \text_titlecase:n{\departmentname}}
 	}
 	{\bool_if:NTF \g_ptxcd_dr_bool
 		{
 			\msg_warning:nnn{apqpub/thesis} {unrecognized-department} {#1}
-			\gdef\ptxcd_department{#1}
+			\gdef\ptxcd_department:{#1}
 			\ptxcd_declare_caption:Nnn \departmentname {Fachbereich} {department}
 		}
 		{\ptxcd_select_studyfield:n {#1}}
@@ -78,21 +77,21 @@
 
 \cs_new:Nn \ptxcd_select_studyfield:n {
 	\str_case:nnTF {#1} {
-		{ce}{\ptxcd_declare_caption:Nnn \ptxcd_department {Computational\nobreakspace Engineering}{Computational\nobreakspace Engineering}}
-		{ese}{\ptxcd_declare_caption:Nnn \ptxcd_department {Energy~Science~and~Engineering}{Energy~Science~and~Engineering}}
-		{ist}{\ptxcd_declare_caption:Nnn \ptxcd_department {Informationssystemtechnik} {Information~Systems~Technology}}
-		{mech}{\ptxcd_declare_caption:Nnn \ptxcd_department {Mechanik}{Mechanics}}
-		{metro}{\ptxcd_declare_caption:Nnn \ptxcd_department {Mechatronik}{Mechatronics}}
+		{ce}{\ptxcd_declare_caption:Nnn \ptxcd_department: {Computational\nobreakspace Engineering}{Computational\nobreakspace Engineering}}
+		{ese}{\ptxcd_declare_caption:Nnn \ptxcd_department: {Energy~Science~and~Engineering}{Energy~Science~and~Engineering}}
+		{ist}{\ptxcd_declare_caption:Nnn \ptxcd_department: {Informationssystemtechnik} {Information~Systems~Technology}}
+		{mech}{\ptxcd_declare_caption:Nnn \ptxcd_department: {Mechanik}{Mechanics}}
+		{metro}{\ptxcd_declare_caption:Nnn \ptxcd_department: {Mechatronik}{Mechatronics}}
 	}
 	{
 		\ptxcd_declare_caption:Nnn \departmentname {Studienbereich} {field~of~study}
-		\ptxcd_declare_caption:Nnn \departmentfullname {\departmentname{}~  \ptxcd_department} {\departmentname{}:~\ptxcd_department}
-		\ptxcd_declare_caption:Nnn \ptxcd_departmentprefix {im~ \departmentname}{in~the~\departmentname}
-		\ptxcd_declare_caption:Nnn \ptxcd_in_department {\ptxcd_departmentprefix{}~\ptxcd_department} {\ptxcd_departmentprefix{}~``\ptxcd_department''}
+		\ptxcd_declare_caption:Nnn \departmentfullname {\departmentname{}~  \ptxcd_department:} {\departmentname{}:~\ptxcd_department:}
+		\ptxcd_declare_caption:Nnn \ptxcd_departmentprefix: {im~ \departmentname}{in~the~\departmentname}
+		\ptxcd_declare_caption:Nnn \ptxcd_in_department {\ptxcd_departmentprefix:{}~\ptxcd_department:} {\ptxcd_departmentprefix:{}~``\ptxcd_department:''}
 	}
 	{
 		\msg_warning:nnn{apqpub/thesis} {unrecognized-department} {#1}
-		\gdef\ptxcd_department{#1}
+		\gdef\ptxcd_department:{#1}
 		\ptxcd_declare_caption:Nnn \departmentname {Fachbereich} {department}
 	}
 }
@@ -103,7 +102,7 @@
 
 \ptxcd_declare_caption:Nnn \ptxcd_byname {von} {by}
 \ptxcd_declare_caption:Nnn \ptxcd_fromname {aus} {from}
-\ptxcd_declare_caption:Nnn \ptxcd_departmentprefix {im~ \departmentname}{in~the~\departmentname{}~ of}
+\ptxcd_declare_caption:Nnn \ptxcd_departmentprefix: {im~ \departmentname}{in~the~\departmentname{}~ of}
 \ptxcd_declare_caption:Nnn \ptxcd_reviewname {Gutachten}{review}
 \ptxcd_declare_caption:Nnnn \ptxcd_examdatename {Tag~ der~ Prüfung}{Date~ of~ thesis~ defense}{Date~ of~ thesis~ defence}
 \ptxcd_declare_caption:Nnn \ptxcd_submissiondatename {Tag~ der~ Einreichung}{Date~ of~ submission}
@@ -114,16 +113,18 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %Fallback content for box if not overwritten
-\newcommand*\ptxcd_box_department {\cs_if_exist_use:NF \departmentfullname {\ptxcd_department}}
+\newcommand*\ptxcd_box_department {\cs_if_exist_use:NF \departmentfullname {\ptxcd_department:}}
 \newcommand*\ptxcd_in_department {}
 \newcommand*{\ptxcd_thesisStatus}{}
 \tl_new:N \g__ptxcd_affidavit_version_tl
+\def\@ThesisTypeArticle{die}
 
 \keys_define:nn {ptxcd/thesis} {
 	dr .choice:,
 	dr/rernat .code:n = \tl_gset:Nn \g_ptxcd_thesis_drtext_tl {Zur~Erlangung~des~Grades~eines~Doktors~der~Naturwissenschaften~(Dr.\,rer.\,nat.)},
 	dr/ing .code:n = \tl_gset:Nn \g_ptxcd_thesis_drtext_tl {Zur~Erlangung~des~akademischen~Grades~Doktor-Ingenieur~(Dr.-Ing.)},
 	dr/phil .code:n =  \tl_gset:Nn \g_ptxcd_thesis_drtext_tl {Zur~Erlangung~des~Grades~eines~Doktor~der~Philosophie~(Dr.\,phil.)},
+	dr/rerpol .code:n = \tl_gset:Nn \g_ptxcd_thesis_drtext_tl {Zur~Erlangung~des~Grades~eines~Doctor~rerum~politicarum (Dr. rer. pol.)},
 	type .choice:,
 	type/sta .code:n = {\def\ptxcd_thesisType{Studienarbeit}
 		\clist_gset:Nn \g_ptxcd_Required_title_data_clist {title, author, date}
@@ -131,13 +132,13 @@
 	},
 %	type/diplom  .code:n = {\def\ptxcd_thesisType{Diplomarbeit}\clist_gset:Nn \g_ptxcd_Required_title_data_clist {title, author, submissiondate, reviewer, department}},
 	type/bsc  .meta:n = {type=bachelor},
-	type/bachelor  .code:n = {\ptxcd_declare_caption:Nnn \ptxcd_thesisType{Bachelorarbeit}{bachelor~ thesis} \clist_gset:Nn \g_ptxcd_Required_title_data_clist {title, author, submissiondate, department, reviewer}\bool_gset_false:N \g_ptxcd_dr_bool},
-	type/pp  .code:n = {\def\ptxcd_thesisType{Project-Proposal}\clist_gset:Nn \g_ptxcd_Required_title_data_clist {title, author, date, department}\bool_gset_false:N \g_ptxcd_dr_bool},
+	type/bachelor  .code:n = {\ptxcd_declare_caption:Nnn \ptxcd_thesisType{Bachelorarbeit}{bachelor~ thesis}\def\@ThesisTypeArticle{die}\clist_gset:Nn \g_ptxcd_Required_title_data_clist {title, author, submissiondate, department, reviewer}\bool_gset_false:N \g_ptxcd_dr_bool},
+	type/pp  .code:n = { \ptxcd_declare_caption:Nnn \ptxcd_thesisType {Project-Proposal}{project~ proposal}\def\@ThesisTypeArticle{das}\clist_gset:Nn \g_ptxcd_Required_title_data_clist {title, author, date, department}\bool_gset_false:N \g_ptxcd_dr_bool},
 	type/msc  .meta:n = {type=master},
-	type/master  .code:n = \ptxcd_declare_caption:Nnn \ptxcd_thesisType{Masterarbeit}{master~ thesis} \clist_gset:Nn \g_ptxcd_Required_title_data_clist {title, author, submissiondate, department, reviewer}\bool_gset_false:N \g_ptxcd_dr_bool,
-	type/dr  .code:n = \ptxcd_declare_caption:Nnn \ptxcd_thesisType{Dissertation}{doctoral~ thesis}\ptxcd_declare_caption:Nnn\ptxcd_thesisStatus{vorgelegte}{submitted}\clist_gset:Nn \g_ptxcd_Required_title_data_clist {title, author, submissiondate , birthplace, department, reviewer}\bool_gset_true:N \g_ptxcd_dr_bool,
-	type/drfinal  .code:n = \ptxcd_declare_caption:Nnn \ptxcd_thesisType {Dissertation}{doctoral~ thesis}\ptxcd_declare_caption:Nnn\ptxcd_thesisStatus{genehmigte}{accepted}\clist_gset:Nn \g_ptxcd_Required_title_data_clist {title, author, submissiondate,examdate, birthplace, department, reviewer}\bool_gset_true:N \g_ptxcd_dr_bool,
-	type/unknown  .code:n = \def\ptxcd_thesisType{#1}\clist_gset:Nn \g_ptxcd_Required_title_data_clist {}\bool_gset_false:N \g_ptxcd_dr_bool,
+	type/master  .code:n = \ptxcd_declare_caption:Nnn \ptxcd_thesisType{Masterarbeit}{master~ thesis}\def\@ThesisTypeArticle{die}\clist_gset:Nn \g_ptxcd_Required_title_data_clist {title, author, submissiondate, department, reviewer}\bool_gset_false:N \g_ptxcd_dr_bool,
+	type/dr  .code:n = \ptxcd_declare_caption:Nnn \ptxcd_thesisType{Dissertation}{doctoral~ thesis}\ptxcd_declare_caption:Nnn\ptxcd_thesisStatus{vorgelegte}{submitted}\def\@ThesisTypeArticle{die}\clist_gset:Nn \g_ptxcd_Required_title_data_clist {title, author, submissiondate , birthplace, department, reviewer}\bool_gset_true:N \g_ptxcd_dr_bool,
+	type/drfinal  .code:n = \ptxcd_declare_caption:Nnn \ptxcd_thesisType {Dissertation}{doctoral~ thesis}\ptxcd_declare_caption:Nnn\ptxcd_thesisStatus{genehmigte}{accepted}\def\@ThesisTypeArticle{die}\clist_gset:Nn \g_ptxcd_Required_title_data_clist {title, author, submissiondate,examdate, birthplace, department, reviewer}\bool_gset_true:N \g_ptxcd_dr_bool,
+	type/unknown  .code:n = \def\ptxcd_thesisType{#1}\clist_gset:Nn \g_ptxcd_Required_title_data_clist {}\def\@ThesisTypeArticle{die}\bool_gset_false:N \g_ptxcd_dr_bool,
 	ignore-missing-data .bool_gset:N = \g_ptxcd_missing_data_warning_bool,
 	ignore-missing-data .initial:n = false,
 	department .tl_gset:N  = \g_ptxcd_department_choice_tl,
@@ -148,6 +149,11 @@
 	noinstbox .bool_gset:N = \g_ptxcd_manual_info_box_bool,
 	instbox .bool_gset_inverse:N = \g_ptxcd_manual_info_box_bool,
 	instbox .initial:n = true,
+	reviewer-on-uppertitleback .bool_gset:N = \g__ptxcd_reviewer_on_uppertitleback_bool,
+	reviewer-on-uppertitleback .initial:n = false,
+	hide-architecture-note .bool_gset_inverse:N = \g__ptxcd_architecture_note_bool,
+	hide-architecture-note .initial:n = false,
+	hide-architecture-note .default:n = true,
 }
 
 
@@ -189,28 +195,28 @@
 \renewcommand*\author[2][]{
 	\seq_gset_split:Nnn \g_ptxcd_author_seq {\and} {#2}
 	\tl_if_empty:nTF {#1}
-	{\def\ptxcd_signature{#2}}
-	{\def\ptxcd_signature{#1}}
+	{\tl_set:Nn \l_ptxcd_signature_tl {#2}}
+	{\tl_set:Nn \l_ptxcd_signature_tl {#1}}
 }
 
 \newcommand*{\studentID}[1]{
-  \gdef\ptxcd_studentID{#1}
+  \tl_set:Nn \l_ptxcd_studentID_tl {#1}
 }
 
 \gdef\ptxcd_institution{}
 \gdef\ptxcd_institute{}
-\gdef\ptxcd_department{}
-\gdef\ptxcd_studentID{}
+\gdef\ptxcd_department:{}
+%\gdef\ptxcd_studentID{}
 
 \NewDocumentCommand{\department}{som}{%
 	\IfBooleanTF{#1}{
-	  \tl_gset:Nn \ptxcd_department {#3}
+	  \tl_gset:Nn \ptxcd_department: {#3}
 	  \tl_gset:Nn \ptxcd_in_department{#3}
 	  \IfNoValueTF {\tl_gset:Nn \ptxcd_box_department {#3}} {\tl_gset:Nn \ptxcd_box_department{#2}}
 	  \clist_remove_all:Nn \g_ptxcd_Required_title_data_clist {department}
 	}{
 	  \tl_gset:Nn \g_ptxcd_department_choice_tl {#3}
-	  \IfNoValueF {#2} {\tl_gset:Nn \ptxcd_departmentprefix {#2}}
+	  \IfNoValueF {#2} {\tl_gset:Nn \ptxcd_departmentprefix: {#2}}
 	}
 }
 
@@ -250,12 +256,14 @@
 	}
 	\int_zero:N \l_tmpb_int
 	\par\vspace*{\baselineskip}
-	\seq_map_inline:Nn \g_ptxcd_reviewer_seq
 	{
-		\int_incr:N \l_tmpb_int
-		\cs_if_exist_use:cF {__ptxcd_reviewname_\int_use:N \l_tmpb_int :}
-			{\int_to_arabic:n {\l_tmpb_int}.~\text_titlecase:n{\ptxcd_reviewname}}
-		:~\exp_not:n {##1}\\
+	\seq_map_inline:Nn \g_ptxcd_reviewer_seq
+		{
+			\int_incr:N \l_tmpb_int
+			\cs_if_exist_use:cF {__ptxcd_reviewname_\int_use:N \l_tmpb_int :}
+				{\int_to_arabic:n {\l_tmpb_int}.~\text_titlecase:n{\ptxcd_reviewname}}
+			:~\exp_not:n {##1}\\
+		}
 	}
 }
 
@@ -298,6 +306,7 @@
 	}
 }
 
+\tl_new:N  \g_ptxcd_license_info_tl
 
 \keys_define:nn {ptxcd/thesis} {
 	urn .tl_gset:N =\g_ptxcd_thesis_urn_tl,
@@ -305,12 +314,77 @@
 	printid .tl_gset:N = \g_ptxcd_thesis_tuprints_tl,
 	printid .initial:V = \c_empty_tl,
 	doi .tl_gset:N = \g_ptxcd_thesis_doi_tl,
-	license .tl_gset:N =  \g_ptxcd_license_info_tl,
-	license .initial:n = {Die~Veröffentlichung~steht~unter~folgender~Creative~Commons~Lizenz:\\
-		Namensnennung~--~Keine~kommerzielle~Nutzung~--~Keine~Bearbeitung~ 2.0~Deutschland\\
-		\url{http://creativecommons.org/licenses/by-nc-nd/2.0/de/}
-	}
+	year .tl_gset:N = \g_ptxcd_thesis_publication_year_tl,
+	year .initial:n = ,
+	license .choices:nn = {cc-by-4.0,cc-by-sa-4.0,cc-by-nc-sa-4.0,cc-by-nc-4.0,cc-by-nd-4.0,cc-by-nc-nd-4.0} {
+		\tl_gset:Nx \g_ptxcd_license_info_tl {\exp_not:N \g__ptxcd_cc_license:n {\l_keys_choice_tl} \exp_not:N \iflanguage{\exp_not:N \bbl@main@language}{}{\exp_not:n {\par\smallskip\otherlanguage{\bbl@main@language}}{\exp_not:N \g__ptxcd_cc_license:n {\l_keys_choice_tl}}}}
+	},
+	license / cc-by-nc-nd-2.0-de .code:n = \tl_gset:Nn  \g_ptxcd_license_info_tl {\use:c {g__ptxcd_cc-by-nc-nd-2.0-de:}},
+	license / inc-1.0-de  .code:n = \tl_gset:Nn \g_ptxcd_license_info_tl {
+		Die~Veröffentlichung~ist~urheberrechtlich~geschützt\newline
+		\url{https://rightsstatements.org/page/InC/1.0/}
+	},
+	license / inc-1.0-en .code:n = \tl_gset:Nn \g_ptxcd_license_info_tl {
+		This~work~is~protected~by~copyright\newline
+		\url{https://rightsstatements.org/page/InC/1.0/}
+	},
+	license / inc-1.0 .code:n = \tl_if_in:NnTF \languagename {german} {\keys_set:nn {ptxcd/thesis}{license=inc-1.0-de}}{\keys_set:nn {ptxcd/thesis}{license=inc-1.0-en}},
+	license / initial .code:n = {\keys_set:nn {ptxcd/thesis} {license=cc-by-4.0}},
+	license / unknown .code:n  = \tl_gset:Nn \g_ptxcd_license_info_tl {#1},
+	license .initial:n = initial,
+	signature .tl_set:N = \l_ptxcd_signature_tl,
+	studentID .tl_set:N = \l_ptxcd_studentID_tl,
+	studentID .initial:n =,
+	signature-image .tl_set:N = \l_ptxcd_signature_image_tl,
+	signature-image .initial:n =,
+	signature-location .tl_set:N = \l_ptxcd_signature_location_tl,
+	signature-location .initial:n = Darmstadt,
 }
+
+\msg_new:nnnn {apqapub/thesis} {default-license-will-change} {
+	TUprints~changed~their~default~license.\\
+	tuda-ci~will~adapt~this~change~in~the~next~major~update.~\\
+	Please~choose~your~license~manually~to~avoid~unintended~changes.
+} {Use~either~the~old~default~value~license=cc-by-nc-nd-2.0-de or~license=cc-by-4.0~or~license={<custom~text>}~with~\string\tuprints.}
+
+
+\cs_new:cn {g__ptxcd_cc-by-nc-nd-2.0-de:} {
+	Die~Veröffentlichung~steht~unter~folgender~Creative~Commons~Lizenz:\\
+	Namensnennung~--~Keine~kommerzielle~Nutzung~--~Keine~Bearbeitung~ 2.0~Deutschland\\
+	\url{http://creativecommons.org/licenses/by-nc-nd/2.0/de/}
+}
+
+\defcaptionname{ngerman, german}{\g__ptxcd_cc_attr_by:}{Namensnennung}
+\defcaptionname{ngerman, german}{\g__ptxcd_cc_attr_nc:}{Nicht~kommerziell}
+\defcaptionname{ngerman, german}{\g__ptxcd_cc_attr_sa:}{Weitergabe~unter~gleichen~Bedingungen}
+\defcaptionname{ngerman, german}{\g__ptxcd_cc_attr_nd:}{Keine~Bearbeitungen}
+
+\defcaptionname{english, USenglish, american, UKenglish, british}{\g__ptxcd_cc_attr_by:}{Attribution}
+\defcaptionname{english, USenglish, american, UKenglish, british}{\g__ptxcd_cc_attr_nc:}{NonCommercial}
+\defcaptionname{english, USenglish, american, UKenglish, british}{\g__ptxcd_cc_attr_sa:}{ShareAlike}
+\defcaptionname{english, USenglish, american, UKenglish, british}{\g__ptxcd_cc_attr_nd:}{NoDerivatives}
+
+\defcaptionname{ngerman,german}{\g__ptxcd_cc_intro:}{Die~Veröffentlichung~steht~unter~folgender~Creative~Commons~Lizenz:}
+\defcaptionname{english, USenglish, american, UKenglish, british}{\g__ptxcd_cc_intro:}{This~work~is~licensed~under~a~Creative~Commons~License:}
+
+\defcaptionname{ngerman,german}{\g__ptxcd_cc_sep:}{~--~}
+\defcaptionname{english, USenglish, american, UKenglish, british}{\g__ptxcd_cc_sep:}{--}
+
+\cs_new:Nn \g__ptxcd_cc_license:n {
+	\group_begin:
+	\g__ptxcd_cc_intro:\\
+	\seq_set_split:Nnn \l_tmpa_seq {-} {#1}
+	\bool_set_false:N \l_tmpa_bool
+	\seq_remove_all:Nn \l_tmpa_seq {cc}
+	\seq_pop_right:NN \l_tmpa_seq \l_tmpa_tl
+	\seq_map_inline:Nn \l_tmpa_seq {
+		\bool_if:NTF \l_tmpa_bool {\g__ptxcd_cc_sep:} {\bool_set_true:N \l_tmpa_bool}
+		\use:c {g__ptxcd_cc_attr_##1:}
+	}~\l_tmpa_tl{}~International\\
+	\url{https://creativecommons.org/licenses/\seq_use:Nn \l_tmpa_seq {-}/\l_tmpa_tl/}
+	\group_end:
+}
+
 
 \newcommand{\tuprints}[1]{%
   \tl_if_in:nnTF {#1} {=}
@@ -318,16 +392,19 @@
 	  {\keys_set:nn {ptxcd/thesis} {printid=#1}}
   \lowertitleback{
   	\urlstyle{same}
+  	\selectlanguage{ngerman}
   	Bitte~zitieren~Sie~dieses~Dokument~als:
     \tl_if_empty:NF \g_ptxcd_thesis_urn_tl {\\URN:~urn:nbn:de:tuda-tuprints-\g_ptxcd_thesis_urn_tl}\\
-    URL:~\url{http://tuprints.ulb.tu-darmstadt.de/\g_ptxcd_thesis_tuprints_tl}\\
-	\tl_if_empty:NF \g_ptxcd_thesis_doi_tl {DOI:~\url{https://doi.org/\g_ptxcd_thesis_doi_tl}}
+    URL:~\url{https://tuprints.ulb.tu-darmstadt.de/\g_ptxcd_thesis_tuprints_tl}\\
+	\tl_if_empty:NF \g_ptxcd_thesis_doi_tl {DOI:~\url{https://doi.org/\g_ptxcd_thesis_doi_tl}\\}
+	\tl_if_empty:NF \g_ptxcd_thesis_publication_year_tl {Jahr~der~Veröffentlichung~auf~TUprints:~\g_ptxcd_thesis_publication_year_tl}
 	\par\vspace{\baselineskip}
     Dieses~Dokument~wird~bereitgestellt~von~tuprints,\\
     E-Publishing-Service~der~TU~Darmstadt\\
-    \url{http://tuprints.ulb.tu-darmstadt.de}\\
+    \url{https://tuprints.ulb.tu-darmstadt.de}\\
    	\url{tuprints@ulb.tu-darmstadt.de}\\[2\baselineskip]
-   \tl_if_empty:NF \g_ptxcd_license_info_tl {\\[2\baselineskip]\g_ptxcd_license_info_tl}
+   \tl_if_empty:NF \g_ptxcd_license_info_tl {\\[2\baselineskip]\g_ptxcd_license_info_tl}\\
+   \doclicenseImage
   }%
 }
 
@@ -336,17 +413,19 @@
 	\tl_if_empty:NF \ptxcd_in_department {\ptxcd_in_department{}~}
 	\seq_if_empty:NF  \g_ptxcd_author_seq {\ptxcd_byname\nobreakspace\@author}
 	\tl_if_empty:NF \ptxcd_birthplace {\space\ptxcd_fromname\space\ptxcd_birthplace}
-	\tl_if_empty:NF \ptxcd_studentID {\space\ptxcd_insert_studentID:n {\ptxcd_studentID}}
+	\tl_if_empty:NF \l_ptxcd_studentID_tl {\space\ptxcd_insert_studentID:n {\l_ptxcd_studentID_tl}}
 }
 
 \uppertitleback{
+	\liningnums
 	\raggedright
 	\@title\par\@subtitle
 	\par\vspace*{\baselineskip}
 	%ignore birthplace on english subject
 	\let\ptxcd_birthplace\@empty
 	\@subject
-	\ptxcd_thesis_print_reviewer:
+	\bool_if:NT \g__ptxcd_reviewer_on_uppertitleback_bool
+		\ptxcd_thesis_print_reviewer:
 	\exp_args:Nx \tl_if_empty:nF {\@date\ptxcd_submissiondate}{
 		\par\vspace*{\baselineskip}
 		\ptxcd_thesis_print_dates:n {\\}
@@ -455,8 +534,8 @@
 		\ptxcd_setup_sponsor_box:
 		\hbox_gset:Nn \g_ptxcd_title_box {
 			\parbox[t]{\linewidth}{
-				\begin{minipage}[b]{\bool_if:NT \g_ptxcd_logo@inhead_bool {.75}\linewidth}
-					\bool_if:NT \g_ptxcd_logo@inhead_bool {\color{textonaccentcolor}}
+				\begin{minipage}[b]{\bool_if:NT \g__ptxcd_LogoInHead_bool {.75}\linewidth}
+                    \bool_lazy_and:nnT {\g_ptxcd_colorback_bool} {\g_ptxcd_colorbacktitle_bool} {\color{textonaccentcolor}}
 					\tl_if_empty:NF \@titlehead {
 						\begin{addmargin}{3mm}
 							{\usekomafont{titlehead}{\@titlehead\par}}
@@ -475,6 +554,7 @@
 						{\rule{0pt}{.5\c_ptxcd_logoheight_dim}}
 					\end{addmargin}
 				\end{minipage}%
+				\bool_if:NT \g_ptxcd_colorbacksubtitle_bool {\color{textonaccentcolor}}
 				\par\nointerlineskip
 				\rule{\linewidth}{\g_ptxcd_titlerule_dim}\par\vspace{\c_ptxcd_rulesep_dim}
 				\begin{addmargin}{3mm}
@@ -499,9 +579,22 @@
 					%\tl_if_empty:NF \g_ptxcd_titleaddendum_tl {\g_ptxcd_titleaddendum_tl\par}			%Edit by Dominik Pfeiffer 2020-04-16
 				%\end{addmargin}\vspace{-7pt}%Edit by Stephan Amann 15.01.2021 \end{addmargin}				
 				\end{addmargin}
-				\rule{\linewidth}{\g_ptxcd_titlerule_dim}\par}}
+				\tl_if_empty:NF \@thanks {
+					\expandafter\fontsize\ptxcd_titlethanks_fontsize:\selectfont\par
+					\rule{\linewidth}{\g_ptxcd_titlerule_dim}\par
+					\begin{addmargin}{3mm}
+						\let\footnotetext\ptxcd_title@footnote
+						\@thanks
+					\end{addmargin}
+					\par\vspace{-\dp\strutbox}
+				}
+                \normalcolor
+				\rule{\linewidth}{\g_ptxcd_titlerule_dim}\par
+			}
+		}
+		\let\@thanks\@empty
 		\bool_if:NF \g_ptxcd_manual_info_box_bool {
-			\exp_args:Nf \tl_if_empty:nF {\ptxcd_institution\ptxcd_department\ptxcd_institute\ptxcd_group} {
+			\exp_args:Nf \tl_if_empty:nF {\ptxcd_institution\ptxcd_department:\ptxcd_institute\ptxcd_group} {
 				\addTitleBox{
 					\setlength{\parskip}{\c_ptxcd_rulesep_dim}
 					\tl_if_empty:NF \ptxcd_institution {\ptxcd_institution\par}
@@ -515,7 +608,6 @@
 		\nointerlineskip\box_use:N \g_ptxcd_title_box
 		\par
 		\vfill
-		\@thanks\let\@thanks\@empty
 		\box_if_empty:NTF \g_ptxcd_sponsor_box {
 			\raisebox{-\c_ptxcd_rulesep_dim}[0pt][0pt]{\rule{\linewidth}{\g_ptxcd_titlerule_dim}}
 		}{
@@ -524,13 +616,13 @@
 		\if@twoside
 			\@tempswatrue
 			\expandafter\ifnum \@nameuse{scr@v@3.12}>\scr@compatibility\relax
-		\else
-			\ifx\@uppertitleback\@empty
+			\else
+				\ifx\@uppertitleback\@empty
 				\ifx\@lowertitleback\@empty
-					\@tempswafalse
+				\@tempswafalse
+				\fi
 				\fi
 			\fi
-		\fi
 		\else
 		\exp_args:Nf \tl_if_empty:nTF  {\g_ptxcd_thesis_urn_tl\g_ptxcd_thesis_tuprints_tl}
 		{\@tempswafalse}
@@ -570,7 +662,6 @@
 }
 
 \newcommand*{\@ThesisType}{\ptxcd_thesisType}
-%\ExplSyntaxOff
 
 \bool_if:NTF \g_ptxcd_dr_bool {
 	\keys_define:nn {ptxcd/thesis} {
@@ -581,14 +672,16 @@
 } {
 	\keys_define:nn {ptxcd/thesis} {
 	affidavit .choices:nn = {digital,print}{\tl_gset_eq:NN  \g__ptxcd_affidavit_version_tl \l_keys_choice_tl},
-	affidavit / default .meta:n = {affidavit=print},
+	affidavit / default .meta:n = {affidavit=digital},
 	affidavit .initial:n = default,
 	}
 }
 
 \NewDocumentCommand{\affidavit}{so}{%
 	\IfNoValueF {#2} {%
-		\csname keys_set:nn\endcsname {ptxcd/thesis} {affidavit=#2}%
+		\tl_if_in:nnTF {#2} {=}
+			{\keys_set:nn {ptxcd/thesis} {#2}}
+			{\keys_set:nn {ptxcd/thesis} {affidavit=#2}}%
 	}%
 	\clearpage
 \begin{otherlanguage}{ngerman}
@@ -608,42 +701,38 @@
 
 \expandafter\def\csname g__ptxcd_affidavit_dr_tl\endcsname {%
 	\section*{Erklärungen laut Promotionsordnung}
-	\subsection*{\S{}8 Abs. 1 lit. c PromO}
+	\subsection*{\S\,8 Abs. 1 lit. c PromO}
 	Ich versichere hiermit, dass die elektronische Version meiner Dissertation mit der schriftlichen Version übereinstimmt.
-	\subsection*{\S{}8 Abs. 1 lit. d PromO}
+	\subsection*{\S\,8 Abs. 1 lit. d PromO}
 	Ich versichere hiermit, dass zu einem vorherigen Zeitpunkt noch keine Promotion versucht wurde. In diesem Fall sind nähere Angaben über Zeitpunkt, Hochschule, Dissertationsthema und Ergebnis dieses Versuchs mitzuteilen.
 
-	\subsection*{\S{}9 Abs. 1 PromO}
-	Ich versichere hiermit, dass die vorliegende Dissertation selbstständig und nur unter Verwendung der angegebenen Quellen verfasst wurde.
+	\subsection*{\S\,9 Abs. 1 PromO}
+	Ich versichere hiermit, dass die vorliegende Dissertation – abgesehen von den in ihr ausdrücklich genannten Hilfen – selbstständig verfasst wurde und dass die „Grundsätze zur Sicherung guter wissenschaftlicher Praxis an der Technischen Universität Darmstadt“ und die „Leitlinien zum Umgang mit digitalen Forschungsdaten an der TU Darmstadt“ in den jeweils aktuellen Versionen bei der Verfassung der Dissertation beachtet wurden.
 
-	\subsection*{\S{}9 Abs. 2 PromO}
+	\subsection*{\S\,9 Abs. 2 PromO}
 	Die Arbeit hat bisher noch nicht zu Prüfungszwecken gedient.
 }
 
+% Quelle: https://www.tu-darmstadt.de/studieren/studierende_tu/studienorganisation_und_tucan/hilfe_und_faq/artikel_details_de_en_37824.de.jsp
 \expandafter\def\csname g__ptxcd_affidavit_digital_tl\endcsname {%
-	\section*{Erklärung zur Abschlussarbeit gemäß\\ \S{}22~Abs.~7~APB TU~Darmstadt}
+	\subsection*{Erklärung zur Abschlussarbeit gemäß \S\,22~Abs.~7~APB TU~Darmstadt}
 	\begin{sloppypar}%
-	Hiermit versichere ich, \@author, die vorliegende \@ThesisType{} gemäß \S{}22~Abs.~7~APB der TU Darmstadt ohne Hilfe Dritter und nur mit den angegebenen Quellen und Hilfsmitteln angefertigt zu haben.
-	Alle Stellen, die Quellen entnommen wurden, sind als solche kenntlich gemacht worden. Diese Arbeit hat in gleicher oder ähnlicher Form noch keiner Prüfungsbehörde vorgelegen.
+	Hiermit erkläre ich, \@author, dass ich die vorliegende Arbeit gemäß \S\,22~Abs.~7~APB der TU Darmstadt selbstständig, ohne Hilfe Dritter und nur mit den angegebenen Quellen und Hilfsmitteln angefertigt habe.
+	 Ich habe mit Ausnahme der zitierten Literatur und anderer in der Arbeit genannter Quellen keine fremden Hilfsmittel benutzt. Die von mir bei der Anfertigung dieser wissenschaftlichen Arbeit wörtlich oder inhaltlich benutzte Literatur und alle anderen Quellen habe ich im Text deutlich gekennzeichnet und gesondert aufgeführt. Dies gilt auch für Quellen oder Hilfsmittel aus dem Internet.
 	\end{sloppypar}%
 	\par
-	Mir ist bekannt, dass im Falle eines Plagiats (\S{}38~Abs.~2 ~APB) ein Täuschungsversuch vorliegt, der dazu führt, dass die Arbeit mit 5,0 bewertet und damit ein Prüfungsversuch verbraucht wird. Abschlussarbeiten dürfen nur einmal wiederholt werden.
+	Diese Arbeit hat in gleicher oder ähnlicher Form noch keiner Prüfungsbehörde vorgelegen.
 	\par
-	Bei einer Thesis des Fachbereichs Architektur entspricht die eingereichte elektronische Fassung dem vorgestellten Modell und den vorgelegten Plänen.
-}
-
-\expandafter\def\csname g__ptxcd_affidavit_print_tl\endcsname {%
-	\section*{Erklärung zur Abschlussarbeit\\gemäß \S{}22~Abs.~7 und \S{}23~Abs.~7~APB der TU~Darmstadt}
-	Hiermit versichere ich, \@author, die vorliegende \@ThesisType{} ohne Hilfe Dritter und nur mit den angegebenen Quellen und Hilfsmitteln angefertigt zu haben. Alle Stellen, die Quellen entnommen wurden, sind als solche kenntlich gemacht worden. Diese Arbeit hat in gleicher oder ähnlicher Form noch keiner Prüfungsbehörde vorgelegen.
-	\par
-	Mir ist bekannt, dass im Fall eines Plagiats (\S{}38~Abs.~2~APB) ein Täuschungsversuch vorliegt, der dazu führt, dass die Arbeit mit 5,0 bewertet und damit ein Prüfungsversuch verbraucht wird. Abschlussarbeiten dürfen nur einmal wiederholt werden.
-	\par
-	Bei der abgegebenen Thesis stimmen die schriftliche und die zur Archivierung eingereichte elektronische Fassung gemäß \S{}23~Abs.~7~APB überein.
-	\par
-	Bei einer Thesis des Fachbereichs Architektur entspricht die eingereichte elektronische Fassung dem vorgestellten Modell und den vorgelegten Plänen.
+	Mir ist bekannt, dass im Falle eines Plagiats (\S\,38~Abs.~2 ~APB) ein Täuschungsversuch vorliegt, der dazu führt, dass die Arbeit mit 5,0 bewertet und damit ein Prüfungsversuch verbraucht wird. Abschlussarbeiten dürfen nur einmal wiederholt werden.
+	\csname bool_if:cT\endcsname {g__ptxcd_architecture_note_bool} {%
+		\par
+		Bei einer Thesis des Fachbereichs Architektur entspricht die eingereichte elektronische Fassung dem vorgestellten Modell und den vorgelegten Plänen.
+	}
 }
 
 \ExplSyntaxOn
+
+\cs_set_eq:NN \g__ptxcd_affidavit_print_tl \g__ptxcd_affidavit_digital_tl
 
 \NewDocumentEnvironment{affidavit*}{om}{
 	\IfNoValueF {#1} {\begin{otherlanguage}{#1}}
@@ -652,13 +741,26 @@
 	\IfNoValueF {#1} {\end{otherlanguage}}
 }
 
-\newcommand*{\AffidavitSignature}[1][Darmstadt]{
+\NewDocumentCommand{\AffidavitSignature}{o}{
 	\par
-	\bigskip
-	\noindent #1,~ \ptxcd_submissiondate\hfill\SignatureBox{\ptxcd_signature}\\\strut
+	\begingroup
+	\IfNoValueF {#1} {%
+		\tl_if_in:nnTF {#1} {=}
+			{\keys_set:nn {ptxcd/thesis} {#1}}
+			{\keys_set:nn {ptxcd/thesis} {signature-location=#1}}%
+	}%
+	\tl_if_empty:NT \l_ptxcd_signature_image_tl {\bigskip}
+	\noindent \l_ptxcd_signature_location_tl,~ \ptxcd_submissiondate\hfill
+	\SignatureBox{\l_ptxcd_signature_tl}
+	\endgroup
+	\\\strut
 }
 
-\newcommand*{\SignatureBox}[2][5cm]{\parbox[t]{#1}{\centering\rule{\linewidth}{.3pt}\\\makebox[0pt][c]{#2}}}
+\newcommand*{\SignatureBox}[2][5cm]{\parbox[t]{#1}{\centering
+		\tl_if_empty:NF \l_ptxcd_signature_image_tl
+			{\let\width\linewidth\l_ptxcd_signature_image_tl\par\nointerlineskip}
+		\rule{\linewidth}{.3pt}\\\makebox[0pt][c]{#2}}
+}
 
 %messages:
 \msg_new:nnn{apqpub/thesis} {dr-field-only} {

--- a/main.tex
+++ b/main.tex
@@ -6,7 +6,7 @@
 \documentclass[
 	ruledheaders=all,% Ebene bis zu der die Überschriften mit Linien abgetrennt werden, vgl. DEMO-TUDaPub
 	class=book,% Basisdokumentenklasse. Wählt die Korrespondierende KOMA-Script Klasse
-	thesis={type=dr, dr=rernat},
+	thesis={type=dr, dr=rernat, reviewer-on-uppertitleback=true},
 	accentcolor=1b,  % APQ blue is not available :(
 	custommargins=geometry,  % required for APQ design
 	marginpar=false,% Kopfzeile und Fußzeile erstrecken sich nicht über die Randnotizspalte


### PR DESCRIPTION
Updated APQ LaTex design from 3.07 to 3.38.

This PR modifies two pages in thesis: `Page 2` and `Page 240`.

Page 2:
---

- A newline is added

![diff-002](https://github.com/PatrickBaus/phd_thesis/assets/15003430/feb0246a-cdc4-46d5-bc90-ba7296503e41)

Page 240:
---

- The affidavit is updated to the latest revision.

![diff-240](https://github.com/PatrickBaus/phd_thesis/assets/15003430/7e915b72-66a8-4834-b6d1-5e6377049f7a)


These two changes are content-wise irrelevant since the thesis has already been handed in.

