### PR TITLE
Reverted changes made to the APQ design to match the TUDA-CI front page.

### DIFF
--- a/apqdesign/apqthesis.cfg
+++ b/apqdesign/apqthesis.cfg
@@ -37,6 +37,7 @@
 {\filedate}{\fileversion}{Special Features for publication type 'thesis' using TU Darmstadt's Corporate Design (tuda-ci)}
 
 \RequirePackage{l3keys2e}
+\RequirePackage{fmtcount}
 
 
 \tl_new:N \g_ptxcd_thesis_drtext_tl
@@ -103,14 +104,10 @@
 \ptxcd_declare_caption:Nnn \ptxcd_byname {von} {by}
 \ptxcd_declare_caption:Nnn \ptxcd_fromname {aus} {from}
 \ptxcd_declare_caption:Nnn \ptxcd_departmentprefix: {im~ \departmentname}{in~the~\departmentname{}~ of}
-\ptxcd_declare_caption:Nnn \ptxcd_reviewname {Gutachten}{review}
+\ptxcd_declare_caption:Nnn \ptxcd_reviewname {Gutachten}{reviewer}
 \ptxcd_declare_caption:Nnnn \ptxcd_examdatename {Tag~ der~ Prüfung}{Date~ of~ thesis~ defense}{Date~ of~ thesis~ defence}
 \ptxcd_declare_caption:Nnn \ptxcd_submissiondatename {Tag~ der~ Einreichung}{Date~ of~ submission}
 \ptxcd_declare_caption:Nnn \ptxcd_studentIDname {Matrikelnummer} {Student\nobreakspace ID}
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\ptxcd_declare_caption:Nnn \ptxcd_thesisdatename {}{}%Edit Stephan Amann 05.12.2020
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %Fallback content for box if not overwritten
 \newcommand*\ptxcd_box_department {\cs_if_exist_use:NF \departmentfullname {\ptxcd_department:}}
@@ -261,7 +258,7 @@
 		{
 			\int_incr:N \l_tmpb_int
 			\cs_if_exist_use:cF {__ptxcd_reviewname_\int_use:N \l_tmpb_int :}
-				{\int_to_arabic:n {\l_tmpb_int}.~\text_titlecase:n{\ptxcd_reviewname}}
+				{\ordinalnum{\l_tmpb_int}~\ptxcd_reviewname}
 			:~\exp_not:n {##1}\\
 		}
 	}
@@ -405,8 +402,7 @@
     E-Publishing-Service~der~TU~Darmstadt\\
     \url{https://tuprints.ulb.tu-darmstadt.de}\\
    	\url{tuprints@ulb.tu-darmstadt.de}\\[2\baselineskip]
-   \tl_if_empty:NF \g_ptxcd_license_info_tl {\\[2\baselineskip]\g_ptxcd_license_info_tl}\\
-   \doclicenseImage
+   \tl_if_empty:NF \g_ptxcd_license_info_tl {\\[2\baselineskip]\doclicenseImage\\\g_ptxcd_license_info_tl}
    \tl_if_empty:NF \g_ptxcd_thesis_front_cover_descriptor_tl {\par\vspace{\baselineskip}\textbf{Cover~art:}~\g_ptxcd_thesis_front_cover_descriptor_tl}
   }%
 }
@@ -483,6 +479,14 @@
 		\ptxcd_check_title_data:cn {TUDa@##1} {##1}
 	}
 	\cs_if_exist_use:N \ptxcd_pass_TitleData:
+	\edef\titlepage@restore{%
+		\noexpand\endgroup
+		\noexpand\global\noexpand\@colht\the\@colht
+		\noexpand\global\noexpand\@colroom\the\@colroom
+		\noexpand\global\vsize\the\vsize
+		\noexpand\global\noexpand\@titlepageiscoverpagefalse
+		\noexpand\let\noexpand\titlepage@restore\noexpand\relax
+	}%
 	\ptxcd_disable_marginpar:
 	\cleardoublepage
 	\begin{titlepage}
@@ -491,14 +495,6 @@
 		}%
 		\def\thefootnote{\fnsymbol{footnote}}
 		\if@titlepageiscoverpage
-		\edef\titlepage@restore{%
-			\noexpand\endgroup
-			\noexpand\global\noexpand\@colht\the\@colht
-			\noexpand\global\noexpand\@colroom\the\@colroom
-			\noexpand\global\vsize\the\vsize
-			\noexpand\global\noexpand\@titlepageiscoverpagefalse
-			\noexpand\let\noexpand\titlepage@restore\noexpand\relax
-		}%
 		\begingroup
 		\topmargin=\dimexpr \coverpagetopmargin-1in\relax
 		\oddsidemargin=\dimexpr \coverpageleftmargin-1in\relax
@@ -552,22 +548,21 @@
 					\raggedright
 					\expandafter\fontsize\ptxcd_titleinfo_fontsize:
 					\selectfont
-					{\ifx\@subtitle\@empty\else\usekomafont{title}{\@subtitle\par}\fi}%{\ifx\@subtitle\@empty\else\usekomafont{subtitle}{\@subtitle\par}\fi}%Edit Dominik Pfeiffer 11.05.2020
-					\usekomafont{title}%\usekomafont{subject}%Edit Dominik Pfeiffer 11.05.2020
+					{\ifx\@subtitle\@empty\else\usekomafont{subtitle}{\@subtitle\par}\fi}%
+					\usekomafont{subject}
 					\bool_if:NT \g_ptxcd_dr_bool {\selectlanguage{ngerman}}
 					\tl_if_empty:NF \g_ptxcd_titleintro_tl {\g_ptxcd_titleintro_tl\par}
 					\tl_if_empty:NF \g_ptxcd_thesis_drtext_tl {\g_ptxcd_thesis_drtext_tl\par}
 					{%
-						\usekomafont{title}%\usekomafont{author}Edit Dominik Pfeiffer 11.05.2020
+						\usekomafont{author}
 						\lineskip 0.75em
-						\footnotesize\textmd\@subject%Edit Dominik Pfeiffer 11.05.2020 \@subject
+						\@subject
 						\par
 					}%
-					{\usekomafont{date}{\footnotesize\textmd\ptxcd_thesisdate}}%{\usekomafont{date}{\ptxcd_thesis_print_dates:n {,~}\par}}%
-					%\ptxcd_thesis_print_reviewer:\par			%Edit by Dominik Pfeiffer 2020-04-16
-					%{\usekomafont{publishers}{\@publishers \par}}%			%Edit by Dominik Pfeiffer 2020-04-16
-					%\tl_if_empty:NF \g_ptxcd_titleaddendum_tl {\g_ptxcd_titleaddendum_tl\par}			%Edit by Dominik Pfeiffer 2020-04-16
-				%\end{addmargin}\vspace{-7pt}%Edit by Stephan Amann 15.01.2021 \end{addmargin}				
+					{\usekomafont{date}{\ptxcd_thesis_print_dates:n {,~}\par}}%
+					\ptxcd_thesis_print_reviewer:\par
+					{\usekomafont{publishers}{\@publishers \par}}%
+					\tl_if_empty:NF \g_ptxcd_titleaddendum_tl {\g_ptxcd_titleaddendum_tl\par}
 				\end{addmargin}
 				\tl_if_empty:NF \@thanks {
 					\expandafter\fontsize\ptxcd_titlethanks_fontsize:\selectfont\par


### PR DESCRIPTION
This PR adds in the two reviewers on the front page and the date block